### PR TITLE
Move tether length/velocity state from Winch to Tether

### DIFF
--- a/data/2plate_kite/quat_struc_geometry.yaml
+++ b/data/2plate_kite/quat_struc_geometry.yaml
@@ -102,7 +102,7 @@ groups:
 ###########################
 tethers:
   headers: [name, start_point, end_point, n_segments,
-            diameter_mm, unit_stiffness, unit_damping, init_len]
+            diameter_mm, unit_stiffness, unit_damping, init_stretched_length]
   data:
     - [main_tether, kcu, ground, 2, 1.0, dyneema, nothing, 20.0]
 

--- a/data/2plate_kite/refine_struc_geometry.yaml
+++ b/data/2plate_kite/refine_struc_geometry.yaml
@@ -91,7 +91,7 @@ pulleys:
 ## Tethers ################
 ###########################
 tethers:
-  headers: [name, start_point, end_point, n_segments, material, diameter_mm, init_len]
+  headers: [name, start_point, end_point, n_segments, material, diameter_mm, init_stretched_length]
   data:
     - [main_tether, kcu, ground, 6, dyneema, 1.0, 20.0]
 

--- a/docs/src/exported_types.md
+++ b/docs/src/exported_types.md
@@ -42,11 +42,11 @@ Segment(name, point_i, point_j, unit_stiffness, unit_damping, diameter; l0, comp
 Pulley
 Pulley(name, segment_i, segment_j, type)
 Tether
-Tether(name, segments; start_point, end_point)
-Tether(name; start_point, end_point, n_segments, unit_stiffness, unit_damping, diameter)
+Tether(name, segments; start_point, end_point, tether_length, initial_tether_length)
+Tether(name; start_point, end_point, n_segments, unit_stiffness, unit_damping, diameter, tether_length, initial_tether_length)
 Winch
-Winch(name, set::Settings, tethers; winch_point, tether_len, tether_vel, brake)
-Winch(name, tethers, gear_ratio, drum_radius, f_coulomb, c_vf, inertia_total; winch_point, tether_len, tether_vel, brake)
+Winch(name, set::Settings, tethers; winch_point, init_vel, brake)
+Winch(name, tethers, gear_ratio, drum_radius, f_coulomb, c_vf, inertia_total; winch_point, init_vel, brake)
 AbstractWing
 BaseWing
 VSMWing

--- a/docs/src/exported_types.md
+++ b/docs/src/exported_types.md
@@ -42,8 +42,8 @@ Segment(name, point_i, point_j, unit_stiffness, unit_damping, diameter; l0, comp
 Pulley
 Pulley(name, segment_i, segment_j, type)
 Tether
-Tether(name, segments; start_point, end_point, tether_length, initial_tether_length)
-Tether(name; start_point, end_point, n_segments, unit_stiffness, unit_damping, diameter, tether_length, initial_tether_length)
+Tether(name, segments, unstretched_length; start_point, end_point, stretched_length)
+Tether(name, unstretched_length; start_point, end_point, n_segments, unit_stiffness, unit_damping, diameter, stretched_length)
 Winch
 Winch(name, set::Settings, tethers; winch_point, init_vel, brake)
 Winch(name, tethers, gear_ratio, drum_radius, f_coulomb, c_vf, inertia_total; winch_point, init_vel, brake)

--- a/docs/src/literate/tutorial_julia.jl
+++ b/docs/src/literate/tutorial_julia.jl
@@ -151,7 +151,7 @@ SymbolicAWEModels.record(lg, sam.sys_struct,                      #hide
 
 ## Group all segments into a tether
 seg_names = [s.name for s in segments]
-tethers = [Tether(:main, seg_names)]
+tethers = [Tether(:main, seg_names, l_tether)]
 
 ## Create a winch connected to the tether
 gear_ratio = 1.0
@@ -291,7 +291,7 @@ SymbolicAWEModels.record(lg, sam.sys_struct,                      #hide
 # Segment(:spring, :anchor, :mass, 1000.0, 50.0, 0.002)
 #
 # ## Tether references segments by name
-# Tether(:main, [:seg1, :seg2])
+# Tether(:main, [:seg1, :seg2], 50.0)
 #
 # ## Winch references tethers and winch point by name
 # Winch(:winch, [:main], 1.0, 0.11, 122.0, 30.6, 0.024;

--- a/docs/src/private_functions.md
+++ b/docs/src/private_functions.md
@@ -126,8 +126,7 @@ SymbolicAWEModels.update_yaml_from_sys_struct!
 ```@docs
 SymbolicAWEModels.segment_cad_length
 SymbolicAWEModels.segment_world_length
-SymbolicAWEModels.autocalc_tether_len
-SymbolicAWEModels.apply_tether_init_lens!
+SymbolicAWEModels.apply_tether_init_stretched_lens!
 SymbolicAWEModels.assign_indices_and_resolve!
 SymbolicAWEModels.resolve_ref
 SymbolicAWEModels.resolve_ref_spec

--- a/docs/src/private_functions.md
+++ b/docs/src/private_functions.md
@@ -17,7 +17,6 @@ SymbolicAWEModels.SimFloat
 SymbolicAWEModels.KVec3
 SymbolicAWEModels.SVec3
 VortexStepMethod.Wing
-SymbolicAWEModels.create_tether
 SymbolicAWEModels.create_vsm_wing
 ```
 
@@ -42,7 +41,6 @@ SymbolicAWEModels.calc_R_v_to_w
 SymbolicAWEModels.cad_to_body_frame
 SymbolicAWEModels.calc_pos
 SymbolicAWEModels.calc_winch_force
-SymbolicAWEModels.find_axis_point
 SymbolicAWEModels.quaternion_to_rotation_matrix
 SymbolicAWEModels.rotation_matrix_to_quaternion
 SymbolicAWEModels.rotate_v_around_k

--- a/docs/src/tutorial_julia.md
+++ b/docs/src/tutorial_julia.md
@@ -159,7 +159,7 @@ applies a torque to reel the tether in or out.
 ```julia
 # Group all segments into a tether
 seg_names = [s.name for s in segments]
-tethers = [Tether(:main, seg_names)]
+tethers = [Tether(:main, seg_names, l_tether)]
 
 # Create a winch connected to the tether
 gear_ratio = 1.0
@@ -304,7 +304,7 @@ other by name:
 Segment(:spring, :anchor, :mass, 1000.0, 50.0, 0.002)
 
 ## Tether references segments by name
-Tether(:main, [:seg1, :seg2])
+Tether(:main, [:seg1, :seg2], 50.0)
 
 ## Winch references tethers and winch point by name
 Winch(:winch, [:main], 1.0, 0.11, 122.0, 30.6, 0.024;

--- a/examples/coupled_2plate_kite_linear_vsm.jl
+++ b/examples/coupled_2plate_kite_linear_vsm.jl
@@ -32,7 +32,7 @@ vsm_set = VortexStepMethod.VSMSettings(
 
 sys = load_sys_struct_from_yaml(struc_yaml;
     system_name=MODEL_NAME, set, vsm_set)
-sam::SymbolicAWEModel = SymbolicAWEModel(set, sys)
+sam = SymbolicAWEModel(set, sys)
 init!(sam; remake=false)
 
 dt = 1.0 / set.sample_freq

--- a/examples/sam_tutorial.jl
+++ b/examples/sam_tutorial.jl
@@ -61,7 +61,7 @@ end
 
 set.v_wind = 0.0
 n_seg = length(segments)
-tethers = [Tether(:main, collect(1:n_seg))]
+tethers = [Tether(:main, collect(1:n_seg), set.l_tether)]
 winches = [Winch(:winch, set, [:main]; winch_point=1)]
 
 sys = SystemStructure("winch", set;

--- a/src/generate_system/accessors.jl
+++ b/src/generate_system/accessors.jl
@@ -173,8 +173,8 @@ get_sum_len(sys::SystemStructure{VSMWing}, idx::Int64) = sys.pulleys[idx].sum_le
 @register_symbolic get_sum_len(sys::SystemStructure{VSMWing}, idx::Int64)
 get_tether_len(sys::SystemStructure{VSMWing}, idx::Int64) = sys.tethers[idx].len
 @register_symbolic get_tether_len(sys::SystemStructure{VSMWing}, idx::Int64)
-get_tether_vel(sys::SystemStructure{VSMWing}, idx::Int64) = sys.tethers[idx].vel
-@register_symbolic get_tether_vel(sys::SystemStructure{VSMWing}, idx::Int64)
+get_winch_vel(sys::SystemStructure{VSMWing}, idx::Int64) = sys.winches[idx].vel
+@register_symbolic get_winch_vel(sys::SystemStructure{VSMWing}, idx::Int64)
 get_unit_stiffness(sys::SystemStructure{VSMWing}, idx::Int64) =
     sys.segments[idx].unit_stiffness
 @register_symbolic get_unit_stiffness(sys::SystemStructure{VSMWing}, idx::Int64)

--- a/src/generate_system/accessors.jl
+++ b/src/generate_system/accessors.jl
@@ -171,9 +171,9 @@ get_moment_frac(sys::SystemStructure{VSMWing}, idx::Int64) = sys.groups[idx].mom
 @register_symbolic get_moment_frac(sys::SystemStructure{VSMWing}, idx::Int64)
 get_sum_len(sys::SystemStructure{VSMWing}, idx::Int64) = sys.pulleys[idx].sum_len
 @register_symbolic get_sum_len(sys::SystemStructure{VSMWing}, idx::Int64)
-get_tether_len(sys::SystemStructure{VSMWing}, idx::Int64) = sys.winches[idx].tether_len
+get_tether_len(sys::SystemStructure{VSMWing}, idx::Int64) = sys.tethers[idx].len
 @register_symbolic get_tether_len(sys::SystemStructure{VSMWing}, idx::Int64)
-get_tether_vel(sys::SystemStructure{VSMWing}, idx::Int64) = sys.winches[idx].tether_vel
+get_tether_vel(sys::SystemStructure{VSMWing}, idx::Int64) = sys.tethers[idx].vel
 @register_symbolic get_tether_vel(sys::SystemStructure{VSMWing}, idx::Int64)
 get_unit_stiffness(sys::SystemStructure{VSMWing}, idx::Int64) =
     sys.segments[idx].unit_stiffness

--- a/src/generate_system/create_sys.jl
+++ b/src/generate_system/create_sys.jl
@@ -170,7 +170,7 @@ function create_sys!(s::SymbolicAWEModel, system::SystemStructure;
         pulley_len(t)[eachindex(pulleys)]
         pulley_vel(t)[eachindex(pulleys)]
         tether_len(t)[eachindex(tethers)]
-        tether_vel(t)[eachindex(tethers)]
+        winch_vel(t)[eachindex(winches)]
     end
 
     # ==================== CALL COMPONENT FUNCTIONS ==================== #
@@ -211,7 +211,7 @@ function create_sys!(s::SymbolicAWEModel, system::SystemStructure;
     # 5. Winch equations (motor dynamics, tether reeling)
     eqs, defaults = winch_eqs!(
         eqs, defaults, winches, tethers, points, psys, pset;
-        point_force, set_values, tether_len, tether_vel
+        point_force, set_values, tether_len, winch_vel
     )
 
     # 6. Tether equations (stretched length, average force)

--- a/src/generate_system/create_sys.jl
+++ b/src/generate_system/create_sys.jl
@@ -165,12 +165,12 @@ function create_sys!(s::SymbolicAWEModel, system::SystemStructure;
         aero_force_point_b = nothing
     end
 
-    # Pulley and tether length state variables (shared between segments, pulleys, winches)
+    # Pulley and tether length state variables
     @variables begin
         pulley_len(t)[eachindex(pulleys)]
         pulley_vel(t)[eachindex(pulleys)]
-        tether_len(t)[eachindex(winches)]
-        tether_vel(t)[eachindex(winches)]
+        tether_len(t)[eachindex(tethers)]
+        tether_vel(t)[eachindex(tethers)]
     end
 
     # ==================== CALL COMPONENT FUNCTIONS ==================== #

--- a/src/generate_system/segment_eqs.jl
+++ b/src/generate_system/segment_eqs.jl
@@ -94,44 +94,32 @@ function segment_eqs!(s, eqs, guesses, points, segments, pulleys, tethers, winch
 
         if in_pulley == 0
             in_tether = 0
+            tether_idx = 0
             for tether in tethers
                 if segment.idx in tether.segment_idxs
-                    in_winch = 0
-                    winch_idx = 0
-                    for winch in winches
-                        if tether.idx in winch.tether_idxs
-                            winch_idx = winch.idx
-                            in_winch += 1
-                        end
-                    end
-                    (in_winch > 1) && error(
-                        "Tether $(tether.idx) is connected " *
-                        "to $in_winch winches; should be " *
-                        "0 or 1.",
-                    )
-
-                    if in_winch == 1
-                        eqs = [
-                            eqs
-                            l0[segment.idx] ~
-                                tether_len[winch_idx] /
-                                length(tether.segment_idxs)
-                        ]
-                    else
-                        # Tether without winch: constant l0
-                        eqs = [eqs;
-                            l0[segment.idx] ~
-                                get_l0(psys, segment.idx)]
-                    end
+                    tether_idx = tether.idx
                     in_tether += 1
                 end
             end
             !(in_tether in [0, 1]) && error(
-                "Segment $(segment.idx) is in $in_tether tethers; should be 0 or 1.",
+                "Segment $(segment.idx) is in " *
+                "$in_tether tethers; should be 0 or 1.",
             )
 
-            if in_tether == 0
-                eqs = [eqs; l0[segment.idx] ~ get_l0(psys, segment.idx)]
+            if in_tether == 1
+                # Segment l0 = tether_len / n_segments
+                # (same for winched and winchless tethers)
+                n_segs = length(
+                    tethers[tether_idx].segment_idxs)
+                eqs = [
+                    eqs
+                    l0[segment.idx] ~
+                        tether_len[tether_idx] / n_segs
+                ]
+            else
+                eqs = [eqs;
+                    l0[segment.idx] ~
+                        get_l0(psys, segment.idx)]
             end
         end
 

--- a/src/generate_system/winch_eqs.jl
+++ b/src/generate_system/winch_eqs.jl
@@ -1,31 +1,31 @@
 # Copyright (c) 2025 Bart van de Lint
 # SPDX-License-Identifier: MPL-2.0
 
-# Winch motor dynamics equation generation
+# Winch motor dynamics and per-tether length equation generation
 
 """
-    winch_eqs!(eqs, defaults, winches, tethers, points, psys, _pset;
+    winch_eqs!(eqs, defaults, winches, tethers, points,
+               psys, _pset;
                point_force, set_values, tether_len, tether_vel)
 
-Generate equations for winch motor dynamics and tether reeling.
+Generate equations for winch motor dynamics and per-tether
+length/velocity state.
 
-# Arguments
-- `eqs`, `defaults`: Accumulating vectors for the MTK system.
-- `winches`: Collection of Winch objects.
-- `tethers`: Collection of Tether objects.
-- `points`: Collection of Point objects.
-- `psys`, `pset`: Symbolic parameters representing system and settings.
-- `point_force`: Symbolic point force variable.
-- `set_values`: Symbolic winch torque setpoint variable.
-- `tether_len`, `tether_vel`: Symbolic tether state variables.
+Each tether gets differential equations for `tether_len` and
+`tether_vel`:
+- **With winch:** driven by `winch_acc` from motor dynamics,
+  gated by `brake` and `speed_controlled`.
+- **Without winch:** `tether_len` is constant (zero velocity).
 
 # Returns
 - Tuple `(eqs, defaults)` with updated equation vectors.
 """
-function winch_eqs!(eqs, defaults, winches, tethers, points, psys, _pset;
-                    point_force, set_values, tether_len, tether_vel)
+function winch_eqs!(eqs, defaults, winches, tethers,
+                    points, psys, _pset;
+                    point_force, set_values,
+                    tether_len, tether_vel)
     @variables begin
-        tether_acc(t)[eachindex(winches)]
+        winch_acc(t)[eachindex(winches)]
         winch_force(t)[eachindex(winches)]
         winch_force_vec(t)[1:3, eachindex(winches)]
         brake(t)[eachindex(winches)]
@@ -38,6 +38,48 @@ function winch_eqs!(eqs, defaults, winches, tethers, points, psys, _pset;
         α_motor(t)[eachindex(winches)]
     end
 
+    # Build tether → winch lookup
+    tether_winch = Dict{Int, Int}()
+    for winch in winches
+        for ti in winch.tether_idxs
+            tether_winch[ti] = winch.idx
+        end
+    end
+
+    # --- Per-tether differential equations ---
+    for tether in tethers
+        if haskey(tether_winch, tether.idx)
+            wi = tether_winch[tether.idx]
+            # Tether with winch: driven by winch dynamics
+            eqs = [
+                eqs
+                D(tether_len[tether.idx]) ~
+                    ifelse(brake[wi] == true, 0,
+                           tether_vel[tether.idx])
+                D(tether_vel[tether.idx]) ~
+                    ifelse(brake[wi] == true, 0,
+                        ifelse(
+                            speed_controlled[wi] == true,
+                            0, winch_acc[wi]))
+            ]
+        else
+            # Winchless tether: constant length
+            eqs = [
+                eqs
+                D(tether_len[tether.idx]) ~ 0
+                D(tether_vel[tether.idx]) ~ 0
+            ]
+        end
+        defaults = [
+            defaults
+            tether_len[tether.idx] =>
+                get_tether_len(psys, tether.idx)
+            tether_vel[tether.idx] =>
+                get_tether_vel(psys, tether.idx)
+        ]
+    end
+
+    # --- Per-winch motor dynamics ---
     for winch in winches
         winch_point_idx = winch.winch_point_idx
         (winch_point_idx > length(points)) &&
@@ -45,54 +87,58 @@ function winch_eqs!(eqs, defaults, winches, tethers, points, psys, _pset;
                   "$winch_point_idx does not exist.")
         F = point_force[:, winch_point_idx]
 
-        gear_ratio = get_winch_gear_ratio(psys, winch.idx)
-        drum_radius = get_winch_drum_radius(psys, winch.idx)
-        f_coulomb = get_winch_f_coulomb(psys, winch.idx)
+        gear_ratio = get_winch_gear_ratio(
+            psys, winch.idx)
+        drum_radius = get_winch_drum_radius(
+            psys, winch.idx)
+        f_coulomb = get_winch_f_coulomb(
+            psys, winch.idx)
         c_vf = get_winch_c_vf(psys, winch.idx)
-        inertia_total = get_winch_inertia_total(psys, winch.idx)
-        friction_eps = get_winch_friction_epsilon(psys, winch.idx)
+        inertia_total = get_winch_inertia_total(
+            psys, winch.idx)
+        friction_eps = get_winch_friction_epsilon(
+            psys, winch.idx)
+
+        # Use first tether velocity for motor speed
+        first_tether_idx = winch.tether_idxs[1]
+        tv = tether_vel[first_tether_idx]
 
         # Smooth sign function to avoid discontinuities
         # at zero velocity. eps controls transition width.
-        smooth_sign(x, eps) = x / sqrt(x * x + eps * eps)
+        smooth_sign(x, eps) =
+            x / sqrt(x * x + eps * eps)
 
         eqs = [
             eqs
-            brake[winch.idx] ~ get_brake(psys, winch.idx)
+            brake[winch.idx] ~
+                get_brake(psys, winch.idx)
             speed_controlled[winch.idx] ~
                 get_speed_controlled(psys, winch.idx)
-            D(tether_len[winch.idx]) ~
-                ifelse(brake[winch.idx] == true, 0,
-                       tether_vel[winch.idx])
-            D(tether_vel[winch.idx]) ~
-                ifelse(brake[winch.idx] == true, 0,
-                    ifelse(speed_controlled[winch.idx] == true,
-                           0, tether_acc[winch.idx]))
 
             # Winch motor, gear, and friction dynamics
             ω_motor[winch.idx] ~
-                gear_ratio / drum_radius * tether_vel[winch.idx]
+                gear_ratio / drum_radius * tv
             tau_friction[winch.idx] ~
-                smooth_sign(ω_motor[winch.idx], friction_eps) *
+                smooth_sign(
+                    ω_motor[winch.idx], friction_eps) *
                 f_coulomb * drum_radius / gear_ratio +
                 c_vf * ω_motor[winch.idx] *
                 drum_radius^2 / gear_ratio^2
             tau_motor[winch.idx] ~ set_values[winch.idx]
             tau_total[winch.idx] ~
                 tau_motor[winch.idx] +
-                drum_radius / gear_ratio * winch_force[winch.idx] -
+                drum_radius / gear_ratio *
+                winch_force[winch.idx] -
                 tau_friction[winch.idx]
-            α_motor[winch.idx] ~ tau_total[winch.idx] / inertia_total
-            tether_acc[winch.idx] ~
-                drum_radius / gear_ratio * α_motor[winch.idx]
+            α_motor[winch.idx] ~
+                tau_total[winch.idx] / inertia_total
+            winch_acc[winch.idx] ~
+                drum_radius / gear_ratio *
+                α_motor[winch.idx]
 
             winch_force_vec[:, winch.idx] ~ F
-            winch_force[winch.idx] ~ norm(winch_force_vec[:, winch.idx])
-        ]
-        defaults = [
-            defaults
-            tether_len[winch.idx] => get_tether_len(psys, winch.idx)
-            tether_vel[winch.idx] => get_tether_vel(psys, winch.idx)
+            winch_force[winch.idx] ~
+                norm(winch_force_vec[:, winch.idx])
         ]
     end
     return eqs, defaults

--- a/src/generate_system/winch_eqs.jl
+++ b/src/generate_system/winch_eqs.jl
@@ -6,16 +6,20 @@
 """
     winch_eqs!(eqs, defaults, winches, tethers, points,
                psys, _pset;
-               point_force, set_values, tether_len, tether_vel)
+               point_force, set_values,
+               tether_len, winch_vel)
 
 Generate equations for winch motor dynamics and per-tether
-length/velocity state.
+length state.
 
-Each tether gets differential equations for `tether_len` and
-`tether_vel`:
-- **With winch:** driven by `winch_acc` from motor dynamics,
+Each tether gets a differential equation for `tether_len`:
+- **With winch:** `D(tether_len) = winch_vel` (shared
+  velocity from the winch motor).
+- **Without winch:** `D(tether_len) = 0` (constant).
+
+Each winch gets a differential equation for `winch_vel`:
+- `D(winch_vel) = winch_acc` (from motor dynamics),
   gated by `brake` and `speed_controlled`.
-- **Without winch:** `tether_len` is constant (zero velocity).
 
 # Returns
 - Tuple `(eqs, defaults)` with updated equation vectors.
@@ -23,7 +27,7 @@ Each tether gets differential equations for `tether_len` and
 function winch_eqs!(eqs, defaults, winches, tethers,
                     points, psys, _pset;
                     point_force, set_values,
-                    tether_len, tether_vel)
+                    tether_len, winch_vel)
     @variables begin
         winch_acc(t)[eachindex(winches)]
         winch_force(t)[eachindex(winches)]
@@ -42,44 +46,42 @@ function winch_eqs!(eqs, defaults, winches, tethers,
     tether_winch = Dict{Int, Int}()
     for winch in winches
         for ti in winch.tether_idxs
+            if haskey(tether_winch, ti)
+                error("Tether $ti is connected " *
+                    "to winch $(tether_winch[ti]) " *
+                    "and winch $(winch.idx). Each " *
+                    "tether can have at most one " *
+                    "winch.")
+            end
             tether_winch[ti] = winch.idx
         end
     end
 
-    # --- Per-tether differential equations ---
+    # --- Per-tether length equations ---
     for tether in tethers
         if haskey(tether_winch, tether.idx)
             wi = tether_winch[tether.idx]
-            # Tether with winch: driven by winch dynamics
             eqs = [
                 eqs
                 D(tether_len[tether.idx]) ~
                     ifelse(brake[wi] == true, 0,
-                           tether_vel[tether.idx])
-                D(tether_vel[tether.idx]) ~
-                    ifelse(brake[wi] == true, 0,
-                        ifelse(
-                            speed_controlled[wi] == true,
-                            0, winch_acc[wi]))
+                           winch_vel[wi])
             ]
         else
             # Winchless tether: constant length
             eqs = [
                 eqs
                 D(tether_len[tether.idx]) ~ 0
-                D(tether_vel[tether.idx]) ~ 0
             ]
         end
         defaults = [
             defaults
             tether_len[tether.idx] =>
                 get_tether_len(psys, tether.idx)
-            tether_vel[tether.idx] =>
-                get_tether_vel(psys, tether.idx)
         ]
     end
 
-    # --- Per-winch motor dynamics ---
+    # --- Per-winch velocity and motor dynamics ---
     for winch in winches
         winch_point_idx = winch.winch_point_idx
         (winch_point_idx > length(points)) &&
@@ -99,10 +101,6 @@ function winch_eqs!(eqs, defaults, winches, tethers,
         friction_eps = get_winch_friction_epsilon(
             psys, winch.idx)
 
-        # Use first tether velocity for motor speed
-        first_tether_idx = winch.tether_idxs[1]
-        tv = tether_vel[first_tether_idx]
-
         # Smooth sign function to avoid discontinuities
         # at zero velocity. eps controls transition width.
         smooth_sign(x, eps) =
@@ -110,6 +108,12 @@ function winch_eqs!(eqs, defaults, winches, tethers,
 
         eqs = [
             eqs
+            D(winch_vel[winch.idx]) ~
+                ifelse(brake[winch.idx] == true, 0,
+                    ifelse(
+                        speed_controlled[winch.idx]
+                            == true,
+                        0, winch_acc[winch.idx]))
             brake[winch.idx] ~
                 get_brake(psys, winch.idx)
             speed_controlled[winch.idx] ~
@@ -117,7 +121,8 @@ function winch_eqs!(eqs, defaults, winches, tethers,
 
             # Winch motor, gear, and friction dynamics
             ω_motor[winch.idx] ~
-                gear_ratio / drum_radius * tv
+                gear_ratio / drum_radius *
+                winch_vel[winch.idx]
             tau_friction[winch.idx] ~
                 smooth_sign(
                     ω_motor[winch.idx], friction_eps) *
@@ -139,6 +144,11 @@ function winch_eqs!(eqs, defaults, winches, tethers,
             winch_force_vec[:, winch.idx] ~ F
             winch_force[winch.idx] ~
                 norm(winch_force_vec[:, winch.idx])
+        ]
+        defaults = [
+            defaults
+            winch_vel[winch.idx] =>
+                get_winch_vel(psys, winch.idx)
         ]
     end
     return eqs, defaults

--- a/src/generate_system/winch_eqs.jl
+++ b/src/generate_system/winch_eqs.jl
@@ -83,6 +83,9 @@ function winch_eqs!(eqs, defaults, winches, tethers,
 
     # --- Per-winch velocity and motor dynamics ---
     for winch in winches
+        isempty(winch.tether_idxs) &&
+            error("Winch $(winch.name): no connected " *
+                  "tethers; at least one is required.")
         winch_point_idx = winch.winch_point_idx
         (winch_point_idx > length(points)) &&
             error("Winch $(winch.name): point " *

--- a/src/model_management.jl
+++ b/src/model_management.jl
@@ -58,12 +58,18 @@ function generate_prob_getters(sys_struct, sys)
     if length(groups) > 0; get_group_state = getu(sys, c.([sys.twist_angle, sys.twist_ω, sys.group_tether_force, sys.group_tether_moment, sys.group_aero_moment])); end
     if length(pulleys) > 0; get_pulley_state = getu(sys, c.([sys.pulley_len, sys.pulley_vel])); end
     if length(winches) > 0
-        get_winch_state = getu(sys, c.([sys.tether_len, sys.tether_vel, sys.tether_acc,
-                                       sys.set_values, sys.winch_force_vec, sys.tau_friction]))
+        get_winch_state = getu(sys, c.([
+            sys.winch_acc,
+            sys.set_values, sys.winch_force_vec,
+            sys.tau_friction]))
         set_set_values = setp(sys, sys.set_values)
         get_set_values = getp(sys, sys.set_values)
     end
-    if length(tethers) > 0; get_tether_state = getu(sys, c(sys.stretched_len)); end
+    if length(tethers) > 0
+        get_tether_state = getu(sys, c.([
+            sys.tether_len, sys.tether_vel,
+            sys.stretched_len]))
+    end
     set_sys = setp(sys, sys.psys)
     set_set = setp(sys, sys.pset)
     get_struct_state = getu(sys, sys.wind_vec_gnd)

--- a/src/model_management.jl
+++ b/src/model_management.jl
@@ -294,6 +294,12 @@ This is the main entry point for setting up the model. It handles:
                    Vortex Step Method (VSM) after initialization.
 - `remake_vsm::Bool`: Recreate VSM wing and aerodynamics from settings (useful after
                       modifying aero_geometry.yaml or other VSM settings).
+- `init_transforms::Bool`: Whether to apply spatial transforms
+                           (translate, rotate, heading) during initialization.
+                           Set to `false` to skip transform application.
+- `apply_tether_lens::Bool`: Whether to scale point positions to match
+                             `tether.init_stretched_len`. Set to `false`
+                             to keep point positions from CAD geometry.
 
 # Returns
 - The initialized `ODEIntegrator`.
@@ -309,6 +315,8 @@ function init!(sam::SymbolicAWEModel;
     ignore_l0::Bool=false,
     remake_vsm::Bool=true,
     reset_vel::Bool=true,
+    init_transforms::Bool=true,
+    apply_tether_lens::Bool=true,
     tunable_params::Bool=false
 )
     prn && @info "Initializing $(sam.sys_struct.name) model..."
@@ -373,7 +381,8 @@ function init!(sam::SymbolicAWEModel;
         end
 
         reinit!(sam.sys_struct, sam.set;
-                ignore_l0, remake_vsm, reset_vel)
+                ignore_l0, remake_vsm, reset_vel,
+                init_transforms, apply_tether_lens)
         # When reset_vel=false, state-dependent u0 changed;
         # force ODEProblem recreation to pick up new defaults.
         if !reset_vel && !isnothing(sam.prob)

--- a/src/model_management.jl
+++ b/src/model_management.jl
@@ -54,12 +54,12 @@ function generate_prob_getters(sys_struct, sys)
             get_vsm_y = nothing
         end
     end
-    if length(segments) > 0; get_segment_state = getu(sys, c.([sys.spring_force, sys.len])); end
+    if length(segments) > 0; get_segment_state = getu(sys, c.([sys.spring_force, sys.len, sys.l0])); end
     if length(groups) > 0; get_group_state = getu(sys, c.([sys.twist_angle, sys.twist_ω, sys.group_tether_force, sys.group_tether_moment, sys.group_aero_moment])); end
     if length(pulleys) > 0; get_pulley_state = getu(sys, c.([sys.pulley_len, sys.pulley_vel])); end
     if length(winches) > 0
         get_winch_state = getu(sys, c.([
-            sys.winch_acc,
+            sys.winch_acc, sys.winch_vel,
             sys.set_values, sys.winch_force_vec,
             sys.tau_friction]))
         set_set_values = setp(sys, sys.set_values)
@@ -67,7 +67,7 @@ function generate_prob_getters(sys_struct, sys)
     end
     if length(tethers) > 0
         get_tether_state = getu(sys, c.([
-            sys.tether_len, sys.tether_vel,
+            sys.tether_len,
             sys.stretched_len]))
     end
     set_sys = setp(sys, sys.psys)

--- a/src/model_management.jl
+++ b/src/model_management.jl
@@ -294,10 +294,10 @@ This is the main entry point for setting up the model. It handles:
                    Vortex Step Method (VSM) after initialization.
 - `remake_vsm::Bool`: Recreate VSM wing and aerodynamics from settings (useful after
                       modifying aero_geometry.yaml or other VSM settings).
-- `init_transforms::Bool`: Whether to apply spatial transforms
+- `apply_transforms::Bool`: Whether to apply spatial transforms
                            (translate, rotate, heading) during initialization.
                            Set to `false` to skip transform application.
-- `apply_tether_lens::Bool`: Whether to scale point positions to match
+- `apply_tether_lengths::Bool`: Whether to scale point positions to match
                              `tether.init_stretched_len`. Set to `false`
                              to keep point positions from CAD geometry.
 
@@ -315,8 +315,8 @@ function init!(sam::SymbolicAWEModel;
     ignore_l0::Bool=false,
     remake_vsm::Bool=true,
     reset_vel::Bool=true,
-    init_transforms::Bool=true,
-    apply_tether_lens::Bool=true,
+    apply_transforms::Bool=true,
+    apply_tether_lengths::Bool=true,
     tunable_params::Bool=false
 )
     prn && @info "Initializing $(sam.sys_struct.name) model..."
@@ -382,7 +382,7 @@ function init!(sam::SymbolicAWEModel;
 
         reinit!(sam.sys_struct, sam.set;
                 ignore_l0, remake_vsm, reset_vel,
-                init_transforms, apply_tether_lens)
+                apply_transforms, apply_tether_lengths)
         # When reset_vel=false, state-dependent u0 changed;
         # force ODEProblem recreation to pick up new defaults.
         if !reset_vel && !isnothing(sam.prob)

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -287,11 +287,11 @@ function update_sys_state!(ss, y::AbstractVector, sam::SymbolicAWEModel, t::Real
             ss.l_tether[2] = y[i]
         elseif isequal(sym, sys.tether_len[3])
             ss.l_tether[3] = y[i]
-        elseif isequal(sym, sys.tether_vel[1])
+        elseif isequal(sym, sys.winch_vel[1])
             ss.v_reelout[1] = y[i]
-        elseif isequal(sym, sys.tether_vel[2])
+        elseif isequal(sym, sys.winch_vel[2])
             ss.v_reelout[2] = y[i]
-        elseif isequal(sym, sys.tether_vel[3])
+        elseif isequal(sym, sys.winch_vel[3])
             ss.v_reelout[3] = y[i]
         elseif isequal(sym, sys.winch_force[1])
             ss.winch_force[1] = y[i]

--- a/src/symbolic_awe_model.jl
+++ b/src/symbolic_awe_model.jl
@@ -262,10 +262,13 @@ function update_sys_state!(ss::SysState, sam::SymbolicAWEModel, zoom=1.0)
     @unpack points, groups, segments, pulleys, winches, wings = sam.sys_struct
 
     # Get the state vectors from the integrator
+    @unpack tethers = sam.sys_struct
     if length(winches) > 0
         for winch in winches
-            ss.l_tether[winch.idx] = winch.tether_len
-            ss.v_reelout[winch.idx] = winch.tether_vel
+            # Use first tether's state for SysState
+            ti = winch.tether_idxs[1]
+            ss.l_tether[winch.idx] = tethers[ti].len
+            ss.v_reelout[winch.idx] = tethers[ti].vel
             ss.winch_force[winch.idx] = norm(winch.force)
             ss.set_torque[winch.idx] = winch.set_value
         end
@@ -529,21 +532,23 @@ function update_sys_struct!(prob::ProbWithAttributes,
         end
     end
     if length(winches) > 0
-        tether_len, tether_vel, tether_acc, set_value, winch_force_vec, friction =
+        winch_acc, set_value, winch_force_vec, friction =
             prob.get_winch_state(integ)
         for winch in winches
-            winch.tether_len = tether_len[winch.idx]
-            winch.tether_vel = tether_vel[winch.idx]
-            winch.tether_acc = tether_acc[winch.idx]
+            winch.acc = winch_acc[winch.idx]
             winch.set_value = set_value[winch.idx]
             winch.force .= winch_force_vec[:, winch.idx]
             winch.friction = friction[winch.idx]
         end
     end
     if length(tethers) > 0
-        stretched_len = prob.get_tether_state(integ)
+        tether_len, tether_vel, stretched_len =
+            prob.get_tether_state(integ)
         for tether in tethers
-            tether.stretched_len = stretched_len[tether.idx]
+            tether.len = tether_len[tether.idx]
+            tether.vel = tether_vel[tether.idx]
+            tether.stretched_len =
+                stretched_len[tether.idx]
         end
     end
     if length(wings) > 0
@@ -673,23 +678,22 @@ function calc_steady_torque(sys_struct::SystemStructure)
 end
 
 """
-    calc_winch_force(tether_vel, tether_acc, motor_torque, set)
+    calc_winch_force(sys, tether_vel, winch_acc, set_values)
 
-Calculate the tensile force on the winch tether based on its motion and motor torque.
-
-This function uses a settings object to define the physical parameters of the winch.
+Calculate the tensile force on each winch tether from its
+motion and motor torque.
 
 # Arguments
-- `tether_vel`: The velocity of the tether [m/s].
-- `tether_acc`: The acceleration of the tether [m/s²].
-- `motor_torque`: The torque applied by the motor [Nm].
-- `set`: A settings struct.
+- `sys::SystemStructure`: System structure with winch params.
+- `tether_vel`: Tether velocities [m/s] per winch.
+- `winch_acc`: Winch accelerations [m/s²] per winch.
+- `set_values`: Motor torque inputs [Nm] per winch.
 
 # Returns
-- The calculated force on the winch tether [N].
+- Vector of winch forces [N].
 """
 function calc_winch_force(sys::SystemStructure,
-        tether_vel, tether_acc, set_values)
+        tether_vel, winch_acc, set_values)
     winches = sys.winches
     smooth_sign(x, eps) = x / sqrt(x * x + eps * eps)
     winch_force = zeros(length(winches))
@@ -697,16 +701,18 @@ function calc_winch_force(sys::SystemStructure,
         @unpack gear_ratio, drum_radius, f_coulomb,
             c_vf, inertia_total,
             friction_epsilon = winches[i]
-        ω_motor = gear_ratio / drum_radius * tether_vel[i]
+        ω_motor = gear_ratio / drum_radius *
+            tether_vel[i]
         tau_friction =
             smooth_sign(ω_motor, friction_epsilon) *
             f_coulomb * drum_radius / gear_ratio +
             c_vf * ω_motor *
             drum_radius^2 / gear_ratio^2
-        tau_motor = set_values[i] # set_value is the motor torque
-        α_motor = tether_acc[i] / drum_radius * gear_ratio
+        tau_motor = set_values[i]
+        α_motor = winch_acc[i] / drum_radius * gear_ratio
         tau_total = α_motor * inertia_total
-        winch_force[i] = (-tau_motor + tau_total + tau_friction) / drum_radius * gear_ratio
+        winch_force[i] = (-tau_motor + tau_total +
+            tau_friction) / drum_radius * gear_ratio
     end
     return winch_force
 end
@@ -727,9 +733,9 @@ end
 """
     unstretched_length(s::SymbolicAWEModel)
 
-Returns the unstretched tether length [m] for each winch.
+Returns the unstretched tether length [m] for each tether.
 """
-unstretched_length(sam::SymbolicAWEModel) = [winch.tether_len for winch in sam.sys_struct.winches]
+unstretched_length(sam::SymbolicAWEModel) = [tether.len for tether in sam.sys_struct.tethers]
 
 """
     tether_length(s::SymbolicAWEModel)
@@ -797,7 +803,7 @@ Sets the kite's depower and steering by adjusting the tether length set-points.
 """
 function set_depower_steering!(sam::SymbolicAWEModel, depower, steering)
     len = sam.set_tether_len
-    len .= [winch.tether_len for winch in sam.sys_struct.winches]
+    len .= [tether.len for tether in sam.sys_struct.tethers]
     depower *= min_chord_len(sam)
     steering *= min_chord_len(sam)
     len[2] = 0.5 * (2*depower + 2*len[1] + steering)

--- a/src/symbolic_awe_model.jl
+++ b/src/symbolic_awe_model.jl
@@ -265,10 +265,10 @@ function update_sys_state!(ss::SysState, sam::SymbolicAWEModel, zoom=1.0)
     @unpack tethers = sam.sys_struct
     if length(winches) > 0
         for winch in winches
-            # Use first tether's state for SysState
+            isempty(winch.tether_idxs) && continue
             ti = winch.tether_idxs[1]
             ss.l_tether[winch.idx] = tethers[ti].len
-            ss.v_reelout[winch.idx] = tethers[ti].vel
+            ss.v_reelout[winch.idx] = winch.vel
             ss.winch_force[winch.idx] = norm(winch.force)
             ss.set_torque[winch.idx] = winch.set_value
         end
@@ -515,10 +515,12 @@ function update_sys_struct!(prob::ProbWithAttributes,
         end
     end
     if length(segments) > 0
-        spring_force, len = prob.get_segment_state(integ)
+        spring_force, len, l0_arr =
+            prob.get_segment_state(integ)
         for segment in segments
             segment.force = spring_force[segment.idx]
             segment.len = len[segment.idx]
+            segment.l0 = l0_arr[segment.idx]
         end
     end
     if length(groups) > 0
@@ -532,21 +534,22 @@ function update_sys_struct!(prob::ProbWithAttributes,
         end
     end
     if length(winches) > 0
-        winch_acc, set_value, winch_force_vec, friction =
+        winch_acc, winch_vel_arr, set_value,
+            winch_force_vec, friction =
             prob.get_winch_state(integ)
         for winch in winches
             winch.acc = winch_acc[winch.idx]
+            winch.vel = winch_vel_arr[winch.idx]
             winch.set_value = set_value[winch.idx]
             winch.force .= winch_force_vec[:, winch.idx]
             winch.friction = friction[winch.idx]
         end
     end
     if length(tethers) > 0
-        tether_len, tether_vel, stretched_len =
+        tether_len, stretched_len =
             prob.get_tether_state(integ)
         for tether in tethers
             tether.len = tether_len[tether.idx]
-            tether.vel = tether_vel[tether.idx]
             tether.stretched_len =
                 stretched_len[tether.idx]
         end
@@ -678,14 +681,14 @@ function calc_steady_torque(sys_struct::SystemStructure)
 end
 
 """
-    calc_winch_force(sys, tether_vel, winch_acc, set_values)
+    calc_winch_force(sys, winch_vel, winch_acc, set_values)
 
 Calculate the tensile force on each winch tether from its
 motion and motor torque.
 
 # Arguments
 - `sys::SystemStructure`: System structure with winch params.
-- `tether_vel`: Tether velocities [m/s] per winch.
+- `winch_vel`: Winch velocities [m/s] per winch.
 - `winch_acc`: Winch accelerations [m/s²] per winch.
 - `set_values`: Motor torque inputs [Nm] per winch.
 
@@ -693,7 +696,7 @@ motion and motor torque.
 - Vector of winch forces [N].
 """
 function calc_winch_force(sys::SystemStructure,
-        tether_vel, winch_acc, set_values)
+        winch_vel, winch_acc, set_values)
     winches = sys.winches
     smooth_sign(x, eps) = x / sqrt(x * x + eps * eps)
     winch_force = zeros(length(winches))
@@ -702,7 +705,7 @@ function calc_winch_force(sys::SystemStructure,
             c_vf, inertia_total,
             friction_epsilon = winches[i]
         ω_motor = gear_ratio / drum_radius *
-            tether_vel[i]
+            winch_vel[i]
         tau_friction =
             smooth_sign(ω_motor, friction_epsilon) *
             f_coulomb * drum_radius / gear_ratio +

--- a/src/symbolic_awe_model.jl
+++ b/src/symbolic_awe_model.jl
@@ -263,15 +263,15 @@ function update_sys_state!(ss::SysState, sam::SymbolicAWEModel, zoom=1.0)
 
     # Get the state vectors from the integrator
     @unpack tethers = sam.sys_struct
-    if length(winches) > 0
-        for winch in winches
-            isempty(winch.tether_idxs) && continue
-            ti = winch.tether_idxs[1]
-            ss.l_tether[winch.idx] = tethers[ti].len
-            ss.v_reelout[winch.idx] = winch.vel
-            ss.winch_force[winch.idx] = norm(winch.force)
-            ss.set_torque[winch.idx] = winch.set_value
-        end
+    for (ti, tether) in enumerate(tethers)
+        ti > 4 && break
+        ss.l_tether[ti] = tether.len
+    end
+    for winch in winches
+        isempty(winch.tether_idxs) && continue
+        ss.v_reelout[winch.idx] = winch.vel
+        ss.winch_force[winch.idx] = norm(winch.force)
+        ss.set_torque[winch.idx] = winch.set_value
     end
     if length(groups) > 0
         # Only fill up to the size of ss.twist_angles (typically 4)

--- a/src/system_structure/system_structure_core.jl
+++ b/src/system_structure/system_structure_core.jl
@@ -105,7 +105,11 @@ function Base.getproperty(sys::SystemStructure, sym::Symbol)
         tethers = getfield(sys, :tethers)
         for tether in tethers
             push!(vars, tether.len)
-            push!(vars, tether.vel)
+        end
+        # winches
+        winches = getfield(sys, :winches)
+        for winch in winches
+            push!(vars, winch.vel)
         end
         return reshape(vars, :, 1) # Return as a column vector (2D array)
     else
@@ -165,7 +169,11 @@ function Base.setproperty!(sys::SystemStructure, sym::Symbol, value)
         for tether in tethers
             tether.len = flat_value[offset]
             offset += 1
-            tether.vel = flat_value[offset]
+        end
+        # winches
+        winches = getfield(sys, :winches)
+        for winch in winches
+            winch.vel = flat_value[offset]
             offset += 1
         end
         return value

--- a/src/system_structure/system_structure_core.jl
+++ b/src/system_structure/system_structure_core.jl
@@ -101,11 +101,11 @@ function Base.getproperty(sys::SystemStructure, sym::Symbol)
                 push!(vars, pulley.vel)
             end
         end
-        # winches
-        winches = getfield(sys, :winches)
-        for winch in winches
-            push!(vars, winch.tether_len)
-            push!(vars, winch.tether_vel)
+        # tethers
+        tethers = getfield(sys, :tethers)
+        for tether in tethers
+            push!(vars, tether.len)
+            push!(vars, tether.vel)
         end
         return reshape(vars, :, 1) # Return as a column vector (2D array)
     else
@@ -160,12 +160,12 @@ function Base.setproperty!(sys::SystemStructure, sym::Symbol, value)
                 offset += 1
             end
         end
-        # winches
-        winches = getfield(sys, :winches)
-        for winch in winches
-            winch.tether_len = flat_value[offset]
+        # tethers
+        tethers = getfield(sys, :tethers)
+        for tether in tethers
+            tether.len = flat_value[offset]
             offset += 1
-            winch.tether_vel = flat_value[offset]
+            tether.vel = flat_value[offset]
             offset += 1
         end
         return value
@@ -365,11 +365,21 @@ function expand_auto_tethers!(
             end
         end
 
-        # Total length from point positions
-        total_len = norm(end_pos - start_pos)
-        seg_l0 = total_len / n
+        # Geometric length from point positions
+        geom_len = norm(end_pos - start_pos)
+
+        # Segment l0: use tether.init_len if set,
+        # otherwise geometric distance
+        rope_len = tether.init_len > 0 ?
+            tether.init_len : geom_len
+        seg_l0 = rope_len / n
+
+        # Store len and init_len on tether
+        tether.len = rope_len
+        tether.init_len = rope_len
 
         # Generate n-1 intermediate DYNAMIC points
+        # (placed along the straight line at geometric spacing)
         dir = end_pos - start_pos
         for i in 1:(n - 1)
             frac = i / n
@@ -771,11 +781,13 @@ function SystemStructure(name, set;
                 seg_last.point_idxs[2]
         end
     end
-    for (i, winch) in enumerate(winches)
-        @assert winch.idx == i
-        if iszero(winch.tether_len)
-            winch.tether_len = autocalc_tether_len(
-                winch, tethers, segments)
+    # Initialize tether.len from segment l0 sums when not set
+    for tether in tethers
+        if iszero(tether.len)
+            tether.len = sum(
+                segments[si].l0 for si in tether.segment_idxs;
+                init=0.0)
+            tether.init_len = tether.len
         end
     end
     # Compute body frame (COM + principal axes) and

--- a/src/system_structure/system_structure_core.jl
+++ b/src/system_structure/system_structure_core.jl
@@ -378,7 +378,7 @@ function expand_auto_tethers!(
 
         # Segment l0: use tether.init_len if set,
         # otherwise geometric distance
-        rope_len = tether.init_len > 0 ?
+        rope_len = !isnan(tether.init_len) ?
             tether.init_len : geom_len
         seg_l0 = rope_len / n
 
@@ -789,9 +789,10 @@ function SystemStructure(name, set;
                 seg_last.point_idxs[2]
         end
     end
-    # Initialize tether.len from segment l0 sums when not set
+    # Initialize tether.len from segment l0 sums when not
+    # explicitly set (tether_length=nothing → len=NaN)
     for tether in tethers
-        if iszero(tether.len)
+        if isnan(tether.len)
             tether.len = sum(
                 segments[si].l0 for si in tether.segment_idxs;
                 init=0.0)

--- a/src/system_structure/system_structure_core.jl
+++ b/src/system_structure/system_structure_core.jl
@@ -373,18 +373,8 @@ function expand_auto_tethers!(
             end
         end
 
-        # Geometric length from point positions
-        geom_len = norm(end_pos - start_pos)
-
-        # Segment l0: use tether.init_len if set,
-        # otherwise geometric distance
-        rope_len = !isnan(tether.init_len) ?
-            tether.init_len : geom_len
-        seg_l0 = rope_len / n
-
-        # Store len and init_len on tether
-        tether.len = rope_len
-        tether.init_len = rope_len
+        seg_l0 = tether.init_unstretched_len / n
+        tether.len = tether.init_unstretched_len
 
         # Generate n-1 intermediate DYNAMIC points
         # (placed along the straight line at geometric spacing)
@@ -787,16 +777,6 @@ function SystemStructure(name, set;
                 seg_first.point_idxs[1]
             tether.end_point_idx =
                 seg_last.point_idxs[2]
-        end
-    end
-    # Initialize tether.len from segment l0 sums when not
-    # explicitly set (tether_length=nothing → len=NaN)
-    for tether in tethers
-        if isnan(tether.len)
-            tether.len = sum(
-                segments[si].l0 for si in tether.segment_idxs;
-                init=0.0)
-            tether.init_len = tether.len
         end
     end
     # Compute body frame (COM + principal axes) and

--- a/src/system_structure/transforms.jl
+++ b/src/system_structure/transforms.jl
@@ -327,7 +327,7 @@ end
 Apply transforms to all components in a `SystemStructure`.
 
 Expects `pos_w` to already be set (via `copy_cad_to_world!` and optionally
-`apply_tether_init_lens!` from `reinit!(sys_struct, set; ...)`).
+`apply_tether_init_stretched_lens!` from `reinit!(sys_struct, set; ...)`).
 Applies: translate (from pos_w) → azimuth/elevation → heading.
 """
 function reinit!(transforms::AbstractVector{Transform}, sys_struct::SystemStructure;
@@ -349,7 +349,7 @@ function reinit!(transforms::AbstractVector{Transform}, sys_struct::SystemStruct
 
         # ==================== TRANSLATE ==================== #
         # T is computed from pos_w of base (via get_base_pos).
-        # After copy_cad_to_world! and apply_tether_init_lens!,
+        # After copy_cad_to_world! and apply_tether_init_stretched_lens!,
         # pos_w reflects any tether scaling already applied.
         base_pos, curr_base_pos = get_base_pos(transform, transforms, wings, points)
         T = base_pos - curr_base_pos

--- a/src/system_structure/types.jl
+++ b/src/system_structure/types.jl
@@ -513,12 +513,23 @@ mutable struct Tether
     const diameter::SimFloat
     "Current stretched length [m] (updated during simulation)."
     stretched_len::SimFloat
-    "Initial tether length [m]. Applied to `pos_w` before transforms. `nothing` = use CAD length."
-    init_len::Union{SimFloat, Nothing}
+    """Unstretched tether length [m] (sum of segment l0).
+    ODE state variable. Segment l0 = len / n_segments."""
+    len::SimFloat
+    "Tether velocity [m/s]. ODE state variable."
+    vel::SimFloat
+    """Initial unstretched length [m]. Used by `init!` to
+    reset `len`. Segment l0 = init_len / n_segments."""
+    init_len::SimFloat
+    """Initial stretched length [m]. Point positions scaled
+    to this value by `apply_tether_init_stretched_lens!`.
+    `nothing` = use CAD length."""
+    init_stretched_len::Union{SimFloat, Nothing}
 end
 
 """
-    Tether(name, segments; start_point=nothing, end_point=nothing)
+    Tether(name, segments; start_point=nothing, end_point=nothing,
+           tether_length=nothing, initial_tether_length=nothing)
 
 Route 1: Construct a `Tether` from explicit segment references.
 
@@ -529,10 +540,17 @@ Route 1: Construct a `Tether` from explicit segment references.
 # Keyword Arguments
 - `start_point=nothing`: Optional start point ref (for validation).
 - `end_point=nothing`: Optional end point ref (for validation).
+- `tether_length=nothing`: Unstretched rope length [m]. Sets
+  segment l0 = tether_length / n_segments. `nothing` = compute
+  from segment l0 values.
+- `initial_tether_length=nothing`: Initial stretched length [m]
+  for point positioning. `nothing` = use CAD positions.
 """
 function Tether(name, segments;
                 start_point=nothing, end_point=nothing,
-                winch_point=nothing, initial_tether_length=nothing)
+                winch_point=nothing,
+                tether_length=nothing,
+                initial_tether_length=nothing)
     if !isnothing(winch_point)
         error("`winch_point` moved from Tether to Winch. " *
               "Use Tether(name, segments) and pass " *
@@ -546,17 +564,21 @@ function Tether(name, segments;
     ep = isnothing(end_point) ? nothing :
         (end_point isa Integer ? Int(end_point) :
          Symbol(end_point))
-    il = isnothing(initial_tether_length) ? nothing :
+    isl = isnothing(initial_tether_length) ? nothing :
         SimFloat(initial_tether_length)
+    il = isnothing(tether_length) ? 0.0 :
+        SimFloat(tether_length)
     return Tether(0, name, Int64[], segment_refs,
                   0, sp, 0, ep,
                   length(segments),
-                  NaN, NaN, NaN, 0.0, il)
+                  NaN, NaN, NaN, 0.0,
+                  il, 0.0, il, isl)
 end
 
 """
     Tether(name; start_point, end_point, n_segments,
-           unit_stiffness=NaN, unit_damping=NaN, diameter=NaN)
+           unit_stiffness=NaN, unit_damping=NaN, diameter=NaN,
+           tether_length=nothing, initial_tether_length=nothing)
 
 Route 2: Construct a `Tether` for auto-generation of intermediate
 points and segments by `expand_auto_tethers!`.
@@ -574,24 +596,33 @@ points and segments by `expand_auto_tethers!`.
   NaN = derive from Settings during auto-expansion.
 - `diameter::Float64=NaN`: Tether diameter [m].
   NaN = derive from Settings during auto-expansion.
+- `tether_length=nothing`: Unstretched rope length [m]. Sets
+  segment l0 = tether_length / n_segments. `nothing` = compute
+  from point positions.
+- `initial_tether_length=nothing`: Initial stretched length [m]
+  for point positioning. `nothing` = use CAD positions.
 """
 function Tether(name; start_point, end_point, n_segments,
                 unit_stiffness=NaN, unit_damping=NaN,
-                diameter=NaN, initial_tether_length=nothing)
+                diameter=NaN, tether_length=nothing,
+                initial_tether_length=nothing)
     sp = start_point isa Integer ? Int(start_point) :
          Symbol(start_point)
     ep = end_point isa Integer ? Int(end_point) :
          Symbol(end_point)
     seg_refs = Vector{NameRef}(
         [Symbol("$(name)_seg_$i") for i in 1:n_segments])
-    il = isnothing(initial_tether_length) ? nothing :
+    isl = isnothing(initial_tether_length) ? nothing :
         SimFloat(initial_tether_length)
+    il = isnothing(tether_length) ? 0.0 :
+        SimFloat(tether_length)
     return Tether(0, name, Int64[], seg_refs,
                   0, sp, 0, ep,
                   Int64(n_segments),
                   Float64(unit_stiffness),
                   Float64(unit_damping),
-                  Float64(diameter), 0.0, il)
+                  Float64(diameter), 0.0,
+                  il, 0.0, il, isl)
 end
 
 # ==================== WINCH ==================== #
@@ -616,14 +647,10 @@ mutable struct Winch
     winch_point_idx::Int64
     "Raw winch point reference (name or index)."
     const winch_point_ref::NameRef
-    "Current tether length [m] (updated during simulation)."
-    tether_len::Union{SimFloat, Nothing}
-    "Current reel-out velocity [m/s]."
-    tether_vel::SimFloat
     "Initial reel-out velocity [m/s]. Applied on reinit!."
     init_vel::SimFloat
-    "Current reel-out acceleration [m/s²]."
-    tether_acc::SimFloat
+    "Current winch acceleration [m/s²] from motor dynamics."
+    acc::SimFloat
     "Control input value (torque [N·m] or speed [m/s])."
     set_value::SimFloat
     "If true, brake is engaged."
@@ -663,8 +690,7 @@ torque or speed regulation.
 # Keyword Arguments
 - `winch_point`: Reference to the ground attachment point
   (name or index). Required.
-- `tether_len::SimFloat=0.0`: Initial tether length [m].
-- `tether_vel::SimFloat=0.0`: Initial reel-out rate [m/s].
+- `init_vel::SimFloat=0.0`: Initial reel-out rate [m/s].
 - `brake::Bool=false`: If true, brake is engaged.
 - `speed_controlled::Bool=false`: If true, velocity is
   prescribed (not integrated).
@@ -673,14 +699,14 @@ torque or speed regulation.
 """
 function Winch(name, set::Settings, tethers;
                winch_point,
-               tether_len=0.0, tether_vel=0.0, brake=false,
+               init_vel=0.0, brake=false,
                speed_controlled=false, friction_epsilon=6.0)
     tether_refs = Vector{NameRef}(
         [t isa Integer ? Int(t) : Symbol(t) for t in tethers])
     wp = winch_point isa Integer ? Int(winch_point) :
          Symbol(winch_point)
     return Winch(0, name, Int64[], tether_refs, 0, wp,
-                 tether_len, tether_vel, tether_vel,
+                 init_vel,
                  0.0, 0.0,
                  brake, speed_controlled, zeros(KVec3),
                  set.gear_ratio, set.drum_radius,
@@ -703,18 +729,19 @@ Constructs a `Winch` by directly providing physical parameters.
 
 # Keyword Arguments
 - `winch_point`: Reference to ground attachment point. Required.
+- `init_vel::SimFloat=0.0`: Initial reel-out rate [m/s].
 """
 function Winch(name, tethers, gear_ratio, drum_radius,
                f_coulomb, c_vf, inertia_total;
                winch_point,
-               tether_len=0.0, tether_vel=0.0, brake=false,
+               init_vel=0.0, brake=false,
                speed_controlled=false, friction_epsilon=6.0)
     tether_refs = Vector{NameRef}(
         [t isa Integer ? Int(t) : Symbol(t) for t in tethers])
     wp = winch_point isa Integer ? Int(winch_point) :
          Symbol(winch_point)
     return Winch(0, name, Int64[], tether_refs, 0, wp,
-                 tether_len, tether_vel, tether_vel,
+                 init_vel,
                  0.0, 0.0,
                  brake, speed_controlled, zeros(KVec3),
                  gear_ratio, drum_radius, f_coulomb,

--- a/src/system_structure/types.jl
+++ b/src/system_structure/types.jl
@@ -516,9 +516,10 @@ mutable struct Tether
     """Unstretched tether length [m] (sum of segment l0).
     ODE state variable. Segment l0 = len / n_segments."""
     len::SimFloat
-    """Initial unstretched length [m]. Used by `init!` to
-    reset `len`. Segment l0 = init_len / n_segments."""
-    init_len::SimFloat
+    """Initial unstretched length [m]. Used by `reinit!`
+    to reset `len`. Segment l0 = init_unstretched_len /
+    n_segments."""
+    init_unstretched_len::SimFloat
     """Initial stretched length [m]. Point positions scaled
     to this value by `apply_tether_init_stretched_lens!`.
     `nothing` = use CAD length."""
@@ -526,33 +527,33 @@ mutable struct Tether
 end
 
 """
-    Tether(name, segments; start_point=nothing, end_point=nothing,
-           tether_length=nothing, initial_tether_length=nothing)
+    Tether(name, segments, unstretched_length;
+           start_point=nothing, end_point=nothing,
+           stretched_length=nothing)
 
 Route 1: Construct a `Tether` from explicit segment references.
 
 # Arguments
 - `name::Union{Int, Symbol}`: Name/identifier for the tether.
 - `segments::Vector`: References to segments (names or indices).
+- `unstretched_length`: Rope length [m]. Sets
+  segment l0 = unstretched_length / n_segments.
 
 # Keyword Arguments
-- `start_point=nothing`: Optional start point ref (for validation).
-- `end_point=nothing`: Optional end point ref (for validation).
-- `tether_length=nothing`: Unstretched rope length [m]. Sets
-  segment l0 = tether_length / n_segments. `nothing` = compute
-  from segment l0 values.
-- `initial_tether_length=nothing`: Initial stretched length [m]
-  for point positioning. `nothing` = use CAD positions.
+- `start_point=nothing`: Optional start point ref.
+- `end_point=nothing`: Optional end point ref.
+- `stretched_length=nothing`: Point positioning target
+  [m]. `nothing` = skip position scaling.
 """
-function Tether(name, segments;
+function Tether(name, segments, unstretched_length;
                 start_point=nothing, end_point=nothing,
                 winch_point=nothing,
-                tether_length=nothing,
-                initial_tether_length=nothing)
+                stretched_length=nothing)
     if !isnothing(winch_point)
-        error("`winch_point` moved from Tether to Winch. " *
-              "Use Tether(name, segments) and pass " *
-              "winch_point to the Winch constructor.")
+        error("`winch_point` moved from Tether to " *
+              "Winch. Use Tether(name, segments, " *
+              "len) and pass winch_point to the " *
+              "Winch constructor.")
     end
     segment_refs = Vector{NameRef}(
         [s isa Integer ? Int(s) : Symbol(s) for s in segments])
@@ -562,10 +563,9 @@ function Tether(name, segments;
     ep = isnothing(end_point) ? nothing :
         (end_point isa Integer ? Int(end_point) :
          Symbol(end_point))
-    isl = isnothing(initial_tether_length) ? nothing :
-        SimFloat(initial_tether_length)
-    il = isnothing(tether_length) ? NaN :
-        SimFloat(tether_length)
+    isl = isnothing(stretched_length) ? nothing :
+        SimFloat(stretched_length)
+    il = SimFloat(unstretched_length)
     return Tether(0, name, Int64[], segment_refs,
                   0, sp, 0, ep,
                   length(segments),
@@ -574,15 +574,18 @@ function Tether(name, segments;
 end
 
 """
-    Tether(name; start_point, end_point, n_segments,
-           unit_stiffness=NaN, unit_damping=NaN, diameter=NaN,
-           tether_length=nothing, initial_tether_length=nothing)
+    Tether(name, unstretched_length;
+           start_point, end_point, n_segments,
+           unit_stiffness=NaN, unit_damping=NaN,
+           diameter=NaN, stretched_length=nothing)
 
 Route 2: Construct a `Tether` for auto-generation of intermediate
 points and segments by `expand_auto_tethers!`.
 
 # Arguments
 - `name::Union{Int, Symbol}`: Name/identifier for the tether.
+- `unstretched_length`: Rope length [m]. Sets
+  segment l0 = unstretched_length / n_segments.
 
 # Keyword Arguments
 - `start_point`: Reference to the start point (required).
@@ -594,26 +597,22 @@ points and segments by `expand_auto_tethers!`.
   NaN = derive from Settings during auto-expansion.
 - `diameter::Float64=NaN`: Tether diameter [m].
   NaN = derive from Settings during auto-expansion.
-- `tether_length=nothing`: Unstretched rope length [m]. Sets
-  segment l0 = tether_length / n_segments. `nothing` = compute
-  from point positions.
-- `initial_tether_length=nothing`: Initial stretched length [m]
-  for point positioning. `nothing` = use CAD positions.
+- `stretched_length=nothing`: Point positioning target
+  [m]. `nothing` = skip position scaling.
 """
-function Tether(name; start_point, end_point, n_segments,
+function Tether(name, unstretched_length;
+                start_point, end_point, n_segments,
                 unit_stiffness=NaN, unit_damping=NaN,
-                diameter=NaN, tether_length=nothing,
-                initial_tether_length=nothing)
+                diameter=NaN, stretched_length=nothing)
     sp = start_point isa Integer ? Int(start_point) :
          Symbol(start_point)
     ep = end_point isa Integer ? Int(end_point) :
          Symbol(end_point)
     seg_refs = Vector{NameRef}(
         [Symbol("$(name)_seg_$i") for i in 1:n_segments])
-    isl = isnothing(initial_tether_length) ? nothing :
-        SimFloat(initial_tether_length)
-    il = isnothing(tether_length) ? NaN :
-        SimFloat(tether_length)
+    isl = isnothing(stretched_length) ? nothing :
+        SimFloat(stretched_length)
+    il = SimFloat(unstretched_length)
     return Tether(0, name, Int64[], seg_refs,
                   0, sp, 0, ep,
                   Int64(n_segments),

--- a/src/system_structure/types.jl
+++ b/src/system_structure/types.jl
@@ -564,7 +564,7 @@ function Tether(name, segments;
          Symbol(end_point))
     isl = isnothing(initial_tether_length) ? nothing :
         SimFloat(initial_tether_length)
-    il = isnothing(tether_length) ? 0.0 :
+    il = isnothing(tether_length) ? NaN :
         SimFloat(tether_length)
     return Tether(0, name, Int64[], segment_refs,
                   0, sp, 0, ep,
@@ -612,7 +612,7 @@ function Tether(name; start_point, end_point, n_segments,
         [Symbol("$(name)_seg_$i") for i in 1:n_segments])
     isl = isnothing(initial_tether_length) ? nothing :
         SimFloat(initial_tether_length)
-    il = isnothing(tether_length) ? 0.0 :
+    il = isnothing(tether_length) ? NaN :
         SimFloat(tether_length)
     return Tether(0, name, Int64[], seg_refs,
                   0, sp, 0, ep,

--- a/src/system_structure/types.jl
+++ b/src/system_structure/types.jl
@@ -516,8 +516,6 @@ mutable struct Tether
     """Unstretched tether length [m] (sum of segment l0).
     ODE state variable. Segment l0 = len / n_segments."""
     len::SimFloat
-    "Tether velocity [m/s]. ODE state variable."
-    vel::SimFloat
     """Initial unstretched length [m]. Used by `init!` to
     reset `len`. Segment l0 = init_len / n_segments."""
     init_len::SimFloat
@@ -572,7 +570,7 @@ function Tether(name, segments;
                   0, sp, 0, ep,
                   length(segments),
                   NaN, NaN, NaN, 0.0,
-                  il, 0.0, il, isl)
+                  il, il, isl)
 end
 
 """
@@ -622,7 +620,7 @@ function Tether(name; start_point, end_point, n_segments,
                   Float64(unit_stiffness),
                   Float64(unit_damping),
                   Float64(diameter), 0.0,
-                  il, 0.0, il, isl)
+                  il, il, isl)
 end
 
 # ==================== WINCH ==================== #
@@ -649,6 +647,8 @@ mutable struct Winch
     const winch_point_ref::NameRef
     "Initial reel-out velocity [m/s]. Applied on reinit!."
     init_vel::SimFloat
+    "Current reel-out velocity [m/s]. ODE state variable."
+    vel::SimFloat
     "Current winch acceleration [m/s²] from motor dynamics."
     acc::SimFloat
     "Control input value (torque [N·m] or speed [m/s])."
@@ -706,7 +706,7 @@ function Winch(name, set::Settings, tethers;
     wp = winch_point isa Integer ? Int(winch_point) :
          Symbol(winch_point)
     return Winch(0, name, Int64[], tether_refs, 0, wp,
-                 init_vel,
+                 init_vel, 0.0,
                  0.0, 0.0,
                  brake, speed_controlled, zeros(KVec3),
                  set.gear_ratio, set.drum_radius,
@@ -741,7 +741,7 @@ function Winch(name, tethers, gear_ratio, drum_radius,
     wp = winch_point isa Integer ? Int(winch_point) :
          Symbol(winch_point)
     return Winch(0, name, Int64[], tether_refs, 0, wp,
-                 init_vel,
+                 init_vel, 0.0,
                  0.0, 0.0,
                  brake, speed_controlled, zeros(KVec3),
                  gear_ratio, drum_radius, f_coulomb,

--- a/src/system_structure/utilities.jl
+++ b/src/system_structure/utilities.jl
@@ -439,10 +439,15 @@ Pulley lengths are initialized proportionally based on current segment lengths:
 - `remake_vsm::Bool=false`: If true, recreate VSM wing, aerodynamics, and solver from settings.
   This is useful after modifying `aero_geometry.yaml` or other VSM-related configuration files.
   For REFINE wings, also rebuilds the `point_to_vsm_point` mapping.
+- `init_transforms::Bool=true`: If false, skip applying spatial transforms
+  (translate, rotate, heading) during reinitialization.
+- `apply_tether_lens::Bool=true`: If false, skip scaling point positions
+  to match `tether.init_stretched_len`.
 """
 function reinit!(sys_struct::SystemStructure, set::Settings;
                  ignore_l0::Bool=false, remake_vsm::Bool=false,
-                 reset_vel::Bool=true)
+                 reset_vel::Bool=true, init_transforms::Bool=true,
+                 apply_tether_lens::Bool=true)
     @unpack points, groups, segments, pulleys, tethers, winches, wings, transforms = sys_struct
 
     # Reset tether len/vel to initial values
@@ -469,7 +474,9 @@ function reinit!(sys_struct::SystemStructure, set::Settings;
     copy_cad_to_world!(points, wings; update_vel=reset_vel)
 
     # Step 2: apply stretched lengths (scales pos_w)
-    apply_tether_init_stretched_lens!(sys_struct)
+    if apply_tether_lens
+        apply_tether_init_stretched_lens!(sys_struct)
+    end
 
     # Step 3: compute segment lengths from pos_w
     for segment in segments
@@ -505,7 +512,9 @@ function reinit!(sys_struct::SystemStructure, set::Settings;
     # Step 5: apply transforms (translate/rotate/heading);
     # pos_w already initialized by copy_cad_to_world! +
     # apply_tether_init_stretched_lens!
-    reinit!(transforms, sys_struct; update_vel=reset_vel)
+    if init_transforms
+        reinit!(transforms, sys_struct; update_vel=reset_vel)
+    end
 
     # Recreate VSM wing and aero if requested
     if remake_vsm

--- a/src/system_structure/utilities.jl
+++ b/src/system_structure/utilities.jl
@@ -37,18 +37,6 @@ function segment_world_length(segment::Segment, points)
     return norm(p1.pos_w - p2.pos_w)
 end
 
-"""
-    autocalc_tether_len(winch::Winch, tethers, segments)
-
-Average unstretched tether length across all tethers connected
-to this winch (sum of segment `l0` per tether, then average).
-"""
-function autocalc_tether_len(winch::Winch, tethers, segments)
-    n = length(winch.tether_idxs)
-    return sum(segments[seg_idx].l0
-               for tether_idx in winch.tether_idxs
-               for seg_idx in tethers[tether_idx].segment_idxs) / n
-end
 
 # ==================== TETHER CREATION ==================== #
 
@@ -450,16 +438,13 @@ function reinit!(sys_struct::SystemStructure, set::Settings;
                  apply_tether_lens::Bool=true)
     @unpack points, groups, segments, pulleys, tethers, winches, wings, transforms = sys_struct
 
-    # Reset tether len/vel to initial values
+    # Reset tether len to initial values
     for tether in tethers
         tether.len = tether.init_len
-        tether.vel = 0.0
     end
-    # Apply winch init_vel to connected tethers
+    # Reset winch velocity to initial value
     for winch in winches
-        for ti in winch.tether_idxs
-            tethers[ti].vel = winch.init_vel
-        end
+        winch.vel = winch.init_vel
     end
 
     for group in groups
@@ -691,34 +676,21 @@ function copy!(sys1::SystemStructure, sys2::SystemStructure)
         end
     end
 
-    # copy tether lengths and velocities
+    # copy tether lengths
     if length(sys1.tethers) > 0 &&
        length(sys1.tethers) == length(sys2.tethers)
         for (tether2, tether1) in
                 zip(sys2.tethers, sys1.tethers)
-            if !simple
-                tether2.len = tether1.len
-                tether2.vel = tether1.vel
-            else
-                seg2 = sys2.segments[
-                    tether2.segment_idxs[1]]
-                pidxs = seg2.point_idxs
-                slen = norm(
-                    sys2.points[pidxs[1]].pos_w .-
-                    sys2.points[pidxs[2]].pos_w)
-                stiffness = seg2.unit_stiffness / slen
-                # Find winch force if connected
-                wforce = zeros(3)
-                for winch in sys1.winches
-                    if tether1.idx in winch.tether_idxs
-                        wforce = winch.force
-                        break
-                    end
-                end
-                tether2.len = slen -
-                    norm(wforce) / stiffness
-                tether2.vel = tether1.vel
-            end
+            tether2.len = tether1.len
+        end
+    end
+
+    # copy winch velocities
+    if length(sys1.winches) > 0 &&
+       length(sys1.winches) == length(sys2.winches)
+        for (winch2, winch1) in
+                zip(sys2.winches, sys1.winches)
+            winch2.vel = winch1.vel
         end
     end
 
@@ -866,14 +838,13 @@ function update_from_sysstate!(sys::SystemStructure, ss::SysState{P}) where P
             winches[i].force .= NaN
             winches[i].friction = NaN
             winches[i].acc = 0.0
+            winches[i].vel = Float64(ss.v_reelout[i])
             winches[i].set_value = Float64(ss.set_torque[i])
-            # Map SysState winch data to tethers
+            # Map SysState tether length to tethers
             for ti in winches[i].tether_idxs
                 if ti <= length(tethers)
                     tethers[ti].len =
                         Float64(ss.l_tether[i])
-                    tethers[ti].vel =
-                        Float64(ss.v_reelout[i])
                 end
             end
         end

--- a/src/system_structure/utilities.jl
+++ b/src/system_structure/utilities.jl
@@ -470,6 +470,17 @@ function reinit!(sys_struct::SystemStructure, set::Settings;
         segment.len = len
     end
 
+    # Step 3b: sync tether segment l0 from tether.len
+    # (matches ODE equation: l0 = tether_len / n_segments)
+    for tether in tethers
+        n = length(tether.segment_idxs)
+        n == 0 && continue
+        l0 = tether.len / n
+        for si in tether.segment_idxs
+            segments[si].l0 = l0
+        end
+    end
+
     for pulley in pulleys
         segment1, segment2 = segments[pulley.segment_idxs[1]],
                              segments[pulley.segment_idxs[2]]

--- a/src/system_structure/utilities.jl
+++ b/src/system_structure/utilities.jl
@@ -570,7 +570,6 @@ The function handles several cases:
 - It also copies the state of wings, groups, winches, and pulleys where applicable.
 """
 function copy!(sys1::SystemStructure, sys2::SystemStructure)
-    simple = false
 
     # copy point pos and vel
     if length(sys1.points) > 0
@@ -605,7 +604,6 @@ function copy!(sys1::SystemStructure, sys2::SystemStructure)
                     sys2.points[point_idxs2[2]].vel_w .= sys1.points[point_idxs1[2]].vel_w
                     sys2.points[point_idxs2[1]].disturb .= sys1.points[point_idxs1[1]].disturb
                     sys2.points[point_idxs2[2]].disturb .= sys1.points[point_idxs1[2]].disturb
-                    simple = true
                 end
             end
         end
@@ -774,23 +772,20 @@ function update_from_sysstate!(sys::SystemStructure, ss::SysState{P}) where P
         end
     end
 
-    # Update winch/tether state from SysState
+    # Update tether lengths from SysState (per-tether)
+    for (ti, tether) in enumerate(tethers)
+        ti > 4 && break
+        tether.len = Float64(ss.l_tether[ti])
+    end
+
+    # Update winch state from SysState (per-winch)
     n_winches = min(length(winches), 4)
     for i in 1:n_winches
-        if i <= length(winches)
-            winches[i].force .= NaN
-            winches[i].friction = NaN
-            winches[i].acc = 0.0
-            winches[i].vel = Float64(ss.v_reelout[i])
-            winches[i].set_value = Float64(ss.set_torque[i])
-            # Map SysState tether length to tethers
-            for ti in winches[i].tether_idxs
-                if ti <= length(tethers)
-                    tethers[ti].len =
-                        Float64(ss.l_tether[i])
-                end
-            end
-        end
+        winches[i].force .= NaN
+        winches[i].friction = NaN
+        winches[i].acc = 0.0
+        winches[i].vel = Float64(ss.v_reelout[i])
+        winches[i].set_value = Float64(ss.set_torque[i])
     end
 
     # Update VSM panel corner positions from world frame back to body frame

--- a/src/system_structure/utilities.jl
+++ b/src/system_structure/utilities.jl
@@ -325,65 +325,66 @@ end
 # ==================== TETHER INIT LEN ==================== #
 
 """
-    apply_tether_init_lens!(sys_struct::SystemStructure)
+    apply_tether_init_stretched_lens!(sys_struct::SystemStructure)
 
-Scale tether point positions in `pos_w` to match each tether's `init_len`.
-Must be called after `copy_cad_to_world!` (so `pos_w == pos_cad` at entry).
+Scale tether point positions in `pos_w` to match each tether's
+`init_stretched_len`. Must be called after `copy_cad_to_world!`
+(so `pos_w == pos_cad` at entry).
 
-For each tether with a non-nothing `init_len`:
-1. Scales all tether points (except start) radially from the start point.
-2. Updates `segment.l0` for the tether's segments.
-3. Sets `winch.tether_len = init_len` for any connected winch.
-4. Propagates the end-point displacement via BFS through non-tether segments,
-   translating downstream `pos_w` by the same delta.
+For each tether with a non-nothing `init_stretched_len`:
+1. Scales all tether points (except start) radially from the
+   start point.
+2. Propagates the end-point displacement via BFS through
+   non-tether segments, translating downstream `pos_w` by the
+   same delta.
 
-Raises an error if a downstream non-tether segment connects back to the
-tether's start point (would create an unsolvable constraint).
+Note: segment `l0` values are NOT updated here — they are set
+from `tether.len` by the ODE equations.
+
+Raises an error if a downstream non-tether segment connects back
+to the tether's start point (would create an unsolvable
+constraint).
 """
-function apply_tether_init_lens!(sys_struct::SystemStructure)
-    @unpack points, segments, tethers, winches = sys_struct
+function apply_tether_init_stretched_lens!(
+    sys_struct::SystemStructure
+)
+    @unpack points, segments, tethers = sys_struct
 
     for tether in tethers
-        isnothing(tether.init_len) && continue
+        isnothing(tether.init_stretched_len) && continue
 
         # Ordered point list: start → intermediates → end
         tether_point_idxs = Int64[tether.start_point_idx]
         for seg_idx in tether.segment_idxs
-            push!(tether_point_idxs, segments[seg_idx].point_idxs[2])
-        end
-
-        # Always set winch tether_len when init_len is specified,
-        # even if no geometric scaling is needed
-        for winch in winches
-            tether.idx in winch.tether_idxs || continue
-            winch.tether_len = tether.init_len
+            push!(tether_point_idxs,
+                segments[seg_idx].point_idxs[2])
         end
 
         current_len = sum(
             segment_world_length(segments[si], points)
             for si in tether.segment_idxs)
-        current_len ≈ tether.init_len && continue
+        target = tether.init_stretched_len
+        current_len ≈ target && continue
         current_len > 0 || error(
             "Tether $(tether.name): current length " *
-            "is zero, cannot scale to init_len")
+            "is zero, cannot scale to " *
+            "init_stretched_len")
 
-        scale = tether.init_len / current_len
-        start_pos = copy(points[tether.start_point_idx].pos_w)
-        old_end_pos = copy(points[tether.end_point_idx].pos_w)
+        scale = target / current_len
+        start_pos = copy(
+            points[tether.start_point_idx].pos_w)
+        old_end_pos = copy(
+            points[tether.end_point_idx].pos_w)
 
         # Scale non-start tether points in pos_w
         for point_idx in tether_point_idxs[2:end]
             pt = points[point_idx]
-            pt.pos_w .= start_pos .+ scale .* (pt.pos_w .- start_pos)
+            pt.pos_w .= start_pos .+
+                scale .* (pt.pos_w .- start_pos)
         end
 
-        # Update segment l0 to match new positions
-        for seg_idx in tether.segment_idxs
-            seg = segments[seg_idx]
-            seg.l0 = segment_world_length(seg, points)
-        end
-
-        delta = points[tether.end_point_idx].pos_w .- old_end_pos
+        delta = points[tether.end_point_idx].pos_w .-
+            old_end_pos
 
         # BFS from end point through non-tether segments;
         # translate downstream pos_w by delta
@@ -403,12 +404,12 @@ function apply_tether_init_lens!(sys_struct::SystemStructure)
                 else
                     continue
                 end
-                # Check start point before visited: start is in visited
-                # but we still want to detect loops back to it
                 if neighbor_idx == tether.start_point_idx
-                    error("Tether $(tether.name): downstream structure " *
-                          "connects back to tether start point. " *
-                          "Cannot apply init_len scaling.")
+                    error("Tether $(tether.name): " *
+                          "downstream structure " *
+                          "connects back to tether " *
+                          "start point. Cannot apply " *
+                          "init_stretched_len scaling.")
                 end
                 neighbor_idx in visited && continue
                 points[neighbor_idx].pos_w .+= delta
@@ -444,8 +445,16 @@ function reinit!(sys_struct::SystemStructure, set::Settings;
                  reset_vel::Bool=true)
     @unpack points, groups, segments, pulleys, tethers, winches, wings, transforms = sys_struct
 
+    # Reset tether len/vel to initial values
+    for tether in tethers
+        tether.len = tether.init_len
+        tether.vel = 0.0
+    end
+    # Apply winch init_vel to connected tethers
     for winch in winches
-        winch.tether_vel = winch.init_vel
+        for ti in winch.tether_idxs
+            tethers[ti].vel = winch.init_vel
+        end
     end
 
     for group in groups
@@ -453,28 +462,20 @@ function reinit!(sys_struct::SystemStructure, set::Settings;
         group.twist_ω = 0.0
     end
 
-    # Transforms are not updated from Settings - YAML structure geometry has priority
+    # Transforms are not updated from Settings -
+    # YAML structure geometry has priority
 
-    # Step 1: copy CAD geometry to world frame (all points and wings)
+    # Step 1: copy CAD geometry to world frame
     copy_cad_to_world!(points, wings; update_vel=reset_vel)
 
-    # Step 2: apply tether initial lengths (scales pos_w; pos_cad unchanged)
-    apply_tether_init_lens!(sys_struct)
+    # Step 2: apply stretched lengths (scales pos_w)
+    apply_tether_init_stretched_lens!(sys_struct)
 
     # Step 3: compute segment lengths from pos_w
     for segment in segments
         len = segment_world_length(segment, points)
         (segment.l0 ≈ 0) && (segment.l0 = len)
         segment.len = len
-    end
-
-    # Step 4: set winch tether_len from segment l0s
-    # (skip if init_len already set it in apply_tether_init_lens!)
-    for winch in winches
-        any(!isnothing(tethers[ti].init_len)
-            for ti in winch.tether_idxs) && continue
-        winch.tether_len = autocalc_tether_len(
-            winch, tethers, segments)
     end
 
     for pulley in pulleys
@@ -502,7 +503,8 @@ function reinit!(sys_struct::SystemStructure, set::Settings;
     sys_struct.wind_vec_gnd .= max(wind_scale_gnd, 1e-6) * wind_vec_rotated
 
     # Step 5: apply transforms (translate/rotate/heading);
-    # pos_w already initialized by copy_cad_to_world! + apply_tether_init_lens!
+    # pos_w already initialized by copy_cad_to_world! +
+    # apply_tether_init_stretched_lens!
     reinit!(transforms, sys_struct; update_vel=reset_vel)
 
     # Recreate VSM wing and aero if requested
@@ -680,26 +682,33 @@ function copy!(sys1::SystemStructure, sys2::SystemStructure)
         end
     end
 
-    # copy winch tether lengths and velocities
-    if length(sys1.winches) > 0 && length(sys1.winches) == length(sys2.winches)
-        for (winch2, winch1) in zip(sys2.winches, sys1.winches)
+    # copy tether lengths and velocities
+    if length(sys1.tethers) > 0 &&
+       length(sys1.tethers) == length(sys2.tethers)
+        for (tether2, tether1) in
+                zip(sys2.tethers, sys1.tethers)
             if !simple
-                winch2.tether_len = winch1.tether_len
-                winch2.tether_vel = winch1.tether_vel
+                tether2.len = tether1.len
+                tether2.vel = tether1.vel
             else
-                tether_len_acc = 0.0
-                for tether_idx in winch1.tether_idxs
-                    tether2 = sys2.tethers[tether_idx]
-                    segment2 = sys2.segments[tether2.segment_idxs[1]]
-                    point_idxs2 = segment2.point_idxs
-                    slen = norm(sys2.points[point_idxs2[1]].pos_w .-
-                                        sys2.points[point_idxs2[2]].pos_w)
-                    stiffness = segment2.unit_stiffness / slen
-                    nt = length(winch1.tether_idxs)
-                    tether_len_acc += (slen - norm(winch1.force)/stiffness/nt) / nt
+                seg2 = sys2.segments[
+                    tether2.segment_idxs[1]]
+                pidxs = seg2.point_idxs
+                slen = norm(
+                    sys2.points[pidxs[1]].pos_w .-
+                    sys2.points[pidxs[2]].pos_w)
+                stiffness = seg2.unit_stiffness / slen
+                # Find winch force if connected
+                wforce = zeros(3)
+                for winch in sys1.winches
+                    if tether1.idx in winch.tether_idxs
+                        wforce = winch.force
+                        break
+                    end
                 end
-                winch2.tether_len = tether_len_acc
-                winch2.tether_vel = winch1.tether_vel
+                tether2.len = slen -
+                    norm(wforce) / stiffness
+                tether2.vel = tether1.vel
             end
         end
     end
@@ -764,7 +773,7 @@ plot(sys)
 - The number of points in `sys` must match the parametric type `P` of `SysState{P}`.
 """
 function update_from_sysstate!(sys::SystemStructure, ss::SysState{P}) where P
-    @unpack points, groups, winches, wings = sys
+    @unpack points, groups, tethers, winches, wings = sys
 
     # Calculate expected total points (regular points + panel corners)
     n_points = length(points)
@@ -841,16 +850,23 @@ function update_from_sysstate!(sys::SystemStructure, ss::SysState{P}) where P
         end
     end
 
-    # Update winch state
-    n_winches = min(length(winches), 4)  # SysState stores up to 4 winches
+    # Update winch/tether state from SysState
+    n_winches = min(length(winches), 4)
     for i in 1:n_winches
         if i <= length(winches)
-            winches[i].tether_len = Float64(ss.l_tether[i])
-            winches[i].tether_vel = Float64(ss.v_reelout[i])
-            winches[i].force .= NaN  # Force not directly available
+            winches[i].force .= NaN
             winches[i].friction = NaN
-            winches[i].tether_acc = 0.0
+            winches[i].acc = 0.0
             winches[i].set_value = Float64(ss.set_torque[i])
+            # Map SysState winch data to tethers
+            for ti in winches[i].tether_idxs
+                if ti <= length(tethers)
+                    tethers[ti].len =
+                        Float64(ss.l_tether[i])
+                    tethers[ti].vel =
+                        Float64(ss.v_reelout[i])
+                end
+            end
         end
     end
 

--- a/src/system_structure/utilities.jl
+++ b/src/system_structure/utilities.jl
@@ -5,7 +5,6 @@
 Utility functions for SystemStructure.
 
 This file contains:
-- Tether creation helpers
 - Validation functions
 - reinit! for SystemStructure
 - State copy and update functions
@@ -38,74 +37,7 @@ function segment_world_length(segment::Segment, points)
 end
 
 
-# ==================== TETHER CREATION ==================== #
 
-"""
-    create_tether(tether_idx, set, points, segments,
-                  tethers, attach_point, dynamics_type;
-                  z, unit_stiffness, unit_damping)
-
-Procedurally create a multi-segment tether.
-
-This function builds a tether from a specified number of
-segments, connecting a given `attach_point` on the kite to
-a new anchor point on the ground.
-"""
-function create_tether(tether_idx, set, points, segments,
-                       tethers, attach_point,
-                       dynamics_type; z=[0,0,1],
-                       unit_stiffness=NaN,
-                       unit_damping=NaN, d_pos=zeros(3))
-    winch_pos = find_axis_point(
-        attach_point.pos_cad, set.l_tether, z) .+ d_pos
-    dir = winch_pos - attach_point.pos_cad
-    segment_idxs = Int64[]
-    ground_point_idx = 0
-    for i in 1:set.segments
-        frac = i / set.segments
-        pos = attach_point.pos_cad + frac * dir
-        point_idx = length(points) + 1
-        segment_idx = length(segments) + 1
-        if i == 1
-            last_idx = attach_point.idx
-        else
-            last_idx = point_idx - 1
-        end
-        if i == set.segments
-            points = [points;
-                Point(point_idx, pos, STATIC)]
-            ground_point_idx = points[end].idx
-        else
-            points = [points;
-                Point(point_idx, pos, dynamics_type)]
-        end
-        segments = [segments;
-            Segment(segment_idx, set, last_idx,
-                    point_idx;
-                    unit_stiffness, unit_damping)]
-        push!(segment_idxs, segment_idx)
-    end
-    tethers = [tethers;
-        Tether(tether_idx, segment_idxs)]
-    return (points, segments, tethers,
-            tethers[end].idx, ground_point_idx)
-end
-
-"""
-    find_axis_point(P, l, v=[0,0,1])
-
-Calculate the coordinates of a point `Q` that lies on a line defined by vector `v`
-and is at a distance `l` from a given point `P`.
-"""
-function find_axis_point(P, l, v=[0,0,1])
-    # Compute discriminant
-    D = (v ⋅ P)^2 - norm(v)^2 * (norm(P)^2 - l^2)
-    D < 0 && error("No real solution: l is too small or parameters invalid")
-    # Solve quadratic for t, choose solution for negative direction
-    t = (v ⋅ P - √D) / norm(v)^2
-    # Compute point Q = t * v
-    return [t * v[1], t * v[2], t * v[3]]
-end
 
 # ==================== VALIDATION ==================== #
 
@@ -427,20 +359,20 @@ Pulley lengths are initialized proportionally based on current segment lengths:
 - `remake_vsm::Bool=false`: If true, recreate VSM wing, aerodynamics, and solver from settings.
   This is useful after modifying `aero_geometry.yaml` or other VSM-related configuration files.
   For REFINE wings, also rebuilds the `point_to_vsm_point` mapping.
-- `init_transforms::Bool=true`: If false, skip applying spatial transforms
+- `apply_transforms::Bool=true`: If false, skip applying spatial transforms
   (translate, rotate, heading) during reinitialization.
-- `apply_tether_lens::Bool=true`: If false, skip scaling point positions
+- `apply_tether_lengths::Bool=true`: If false, skip scaling point positions
   to match `tether.init_stretched_len`.
 """
 function reinit!(sys_struct::SystemStructure, set::Settings;
                  ignore_l0::Bool=false, remake_vsm::Bool=false,
-                 reset_vel::Bool=true, init_transforms::Bool=true,
-                 apply_tether_lens::Bool=true)
+                 reset_vel::Bool=true, apply_transforms::Bool=true,
+                 apply_tether_lengths::Bool=true)
     @unpack points, groups, segments, pulleys, tethers, winches, wings, transforms = sys_struct
 
     # Reset tether len to initial values
     for tether in tethers
-        tether.len = tether.init_len
+        tether.len = tether.init_unstretched_len
     end
     # Reset winch velocity to initial value
     for winch in winches
@@ -459,7 +391,7 @@ function reinit!(sys_struct::SystemStructure, set::Settings;
     copy_cad_to_world!(points, wings; update_vel=reset_vel)
 
     # Step 2: apply stretched lengths (scales pos_w)
-    if apply_tether_lens
+    if apply_tether_lengths
         apply_tether_init_stretched_lens!(sys_struct)
     end
 
@@ -508,7 +440,7 @@ function reinit!(sys_struct::SystemStructure, set::Settings;
     # Step 5: apply transforms (translate/rotate/heading);
     # pos_w already initialized by copy_cad_to_world! +
     # apply_tether_init_stretched_lens!
-    if init_transforms
+    if apply_transforms
         reinit!(transforms, sys_struct; update_vel=reset_vel)
     end
 

--- a/src/yaml_loader.jl
+++ b/src/yaml_loader.jl
@@ -324,9 +324,10 @@ starting from 1 with no gaps.
 
 - `groups`: (optional) table with headers `[id,point_idxs,gamma,type,reference_chord_frac]`
 - `tethers`: (optional) table with headers
-  - Route 1 (explicit segments): `[name, segment_idxs]`, optional: `init_len`
-  - Route 2 (auto-generated): `[name, start_point, end_point, n_segments, material]`, optional: `init_len`
-  - `init_len`: initial tether length [m]; scales `pos_w` before transforms, `pos_cad` unchanged
+  - Route 1 (explicit segments): `[name, segment_idxs]`, optional lengths
+  - Route 2 (auto-generated): `[name, start_point, end_point, n_segments, material]`, optional lengths
+  - `init_stretched_length`: scales `pos_w` before transforms [m]
+  - `init_unstretched_length`: rope length for segment l0 [m]
 - `winches`: (optional) table with headers `[name, tether_idxs, winch_point]`
 - `wings`: (optional, typically from VSM configuration)
 - `transforms`: (optional, typically from settings)
@@ -597,43 +598,52 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                     nothing
                 end
                 il = if hasfield(typeof(row),
-                        :init_len) &&
-                        !isnothing(row.init_len)
-                    Float64(row.init_len)
+                        :init_stretched_length) &&
+                        !isnothing(
+                            row.init_stretched_length)
+                    Float64(row.init_stretched_length)
                 else
                     nothing
                 end
                 tl = if hasfield(typeof(row),
-                        :tether_length) &&
-                        !isnothing(row.tether_length)
-                    Float64(row.tether_length)
+                        :init_unstretched_length) &&
+                        !isnothing(
+                            row.init_unstretched_length)
+                    Float64(
+                        row.init_unstretched_length)
                 else
-                    # init_len sets both unstretched and
-                    # stretched length (backwards compat)
-                    il
+                    nothing
                 end
-                tether = Tether(tether_name, segs;
+                # Default: unstretched = stretched
+                ul = !isnothing(tl) ? tl :
+                    !isnothing(il) ? il :
+                    error("Tether $tether_name: " *
+                        "init_unstretched_length or " *
+                        "init_stretched_length required")
+                tether = Tether(tether_name, segs, ul;
                     start_point=sp, end_point=ep,
-                    tether_length=tl,
-                    initial_tether_length=il)
+                    stretched_length=il)
             else
                 # Route 2: auto-generation
                 sp = yaml_to_ref(row.start_point)
                 ep = yaml_to_ref(row.end_point)
                 n_seg = Int(row.n_segments)
                 il = if hasfield(typeof(row),
-                        :init_len) &&
-                        !isnothing(row.init_len)
-                    Float64(row.init_len)
+                        :init_stretched_length) &&
+                        !isnothing(
+                            row.init_stretched_length)
+                    Float64(row.init_stretched_length)
                 else
                     nothing
                 end
                 tl = if hasfield(typeof(row),
-                        :tether_length) &&
-                        !isnothing(row.tether_length)
-                    Float64(row.tether_length)
+                        :init_unstretched_length) &&
+                        !isnothing(
+                            row.init_unstretched_length)
+                    Float64(
+                        row.init_unstretched_length)
                 else
-                    il
+                    nothing
                 end
                 # Resolve material reference if present
                 resolved = resolve_references(
@@ -655,12 +665,18 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                     Float64(d_mm)
                 d = isnan(d_mm) ? NaN :
                     d_mm * 0.001
-                tether = Tether(tether_name;
+                # Default: unstretched = stretched
+                ul = !isnothing(tl) ? tl :
+                    !isnothing(il) ? il :
+                    error("Tether $tether_name: " *
+                        "init_unstretched_length or " *
+                        "init_stretched_length required")
+                tether = Tether(tether_name, ul;
                     start_point=sp, end_point=ep,
                     n_segments=n_seg,
                     unit_stiffness=us, unit_damping=ud,
-                    diameter=d, tether_length=tl,
-                    initial_tether_length=il)
+                    diameter=d,
+                    stretched_length=il)
             end
             push!(tethers, tether)
         end
@@ -1054,7 +1070,75 @@ function update_yaml_from_sys_struct!(sys_struct::SystemStructure,
         end
     end
 
-    @info "Updated structural positions and segments" n_points=n_points_updated n_segments=n_segments_updated
+    # Build tether init_len dictionary
+    tether_init_lens = Dict{String, Float64}()
+    for tether in sys_struct.tethers
+        name = string(tether.name)
+        if !isnothing(tether.init_stretched_len)
+            tether_init_lens[name] =
+                tether.init_stretched_len
+        end
+    end
+
+    # Update tether init_len values in tethers section
+    n_tethers_updated = 0
+    in_tethers_section = false
+    tether_init_len_col = 0
+    for (i, line) in enumerate(lines)
+        if occursin(r"^tethers:", line)
+            in_tethers_section = true
+            in_points_section = false
+            in_segments_section = false
+        elseif occursin(r"^\w+:", line) &&
+               !occursin(r"^tethers:", line)
+            if in_tethers_section
+                in_tethers_section = false
+                tether_init_len_col = 0
+            end
+        end
+
+        if in_tethers_section
+            # Find init_len column index from headers
+            hm = match(r"headers:\s*\[(.+)\]", line)
+            if hm !== nothing
+                cols = split(hm.captures[1], r",\s*")
+                for (ci, c) in enumerate(cols)
+                    if strip(c) == "init_stretched_length"
+                        tether_init_len_col = ci
+                    end
+                end
+            end
+
+            # Update data rows if we know the column
+            if tether_init_len_col > 0
+                dm = match(
+                    r"^(\s*-\s*\[)(\w+)(.*)", line)
+                if dm !== nothing
+                    name = String(dm.captures[2])
+                    if haskey(tether_init_lens, name)
+                        # Parse fields, update init_len
+                        rest = dm.captures[3]
+                        fields = split(
+                            strip(rest, [',', ']']),
+                            r",\s*")
+                        col = tether_init_len_col - 1
+                        if col <= length(fields)
+                            fields[col] = " " * string(
+                                format_coord(
+                                    tether_init_lens[
+                                        name]))
+                            lines[i] = dm.captures[1] *
+                                name * "," *
+                                join(fields, ",") * "]"
+                            n_tethers_updated += 1
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    @info "Updated structural positions and segments" n_points=n_points_updated n_segments=n_segments_updated n_tethers=n_tethers_updated
 
     # Write updated structural YAML
     @info "Writing updated structural YAML" source=struc_full_path dest=dest_struc_full_path
@@ -1127,12 +1211,14 @@ end
     update_sys_struct_from_yaml!(sys_struct::SystemStructure,
                                   struc_yaml::AbstractString)
 
-Update an existing `SystemStructure` in-place from a (possibly modified)
-structural geometry YAML file. Inverse of `update_yaml_from_sys_struct!`.
+Update an existing `SystemStructure` in-place from a (possibly
+modified) structural geometry YAML file. Inverse of
+`update_yaml_from_sys_struct!`.
 
-Updates `pos_cad` for points and `l0` for segments, matched by symbolic
-name. When `l0` is `nothing` in the YAML, it is auto-calculated from the
-endpoint `pos_cad` positions.
+Updates `pos_cad` for points, `l0` for segments, and
+`init_stretched_len`/`init_unstretched_len` for tethers,
+matched by symbolic name. When `l0` is `nothing` in the
+YAML, it is auto-calculated from endpoint `pos_cad`.
 
 Only raw geometry is updated. Call `reinit!(sys_struct, set)` afterward
 to recompute derived quantities (`pos_b`, `pos_w`, wing frames, etc.).
@@ -1200,6 +1286,36 @@ function update_sys_struct_from_yaml!(
         end
     end
 
-    @info "update_sys_struct_from_yaml!" n_points n_segments
+    # --- Update tether init lengths ---
+    n_tethers = 0
+    if haskey(data, "tethers")
+        tether_rows = parse_table(data["tethers"])
+        for row in tether_rows
+            haskey(row, :name) || continue
+            name = Symbol(row.name)
+            haskey(sys_struct.tethers, name) || continue
+
+            tether = sys_struct.tethers[name]
+
+            if hasfield(typeof(row),
+                    :init_stretched_length) &&
+               !isnothing(row.init_stretched_length)
+                tether.init_stretched_len =
+                    Float64(row.init_stretched_length)
+            end
+            if hasfield(typeof(row),
+                    :init_unstretched_length) &&
+               !isnothing(
+                    row.init_unstretched_length)
+                tether.init_unstretched_len =
+                    Float64(
+                        row.init_unstretched_length)
+            end
+
+            n_tethers += 1
+        end
+    end
+
+    @info "update_sys_struct_from_yaml!" n_points n_segments n_tethers
     return nothing
 end

--- a/src/yaml_loader.jl
+++ b/src/yaml_loader.jl
@@ -603,8 +603,18 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                 else
                     nothing
                 end
+                tl = if hasfield(typeof(row),
+                        :tether_length) &&
+                        !isnothing(row.tether_length)
+                    Float64(row.tether_length)
+                else
+                    # init_len sets both unstretched and
+                    # stretched length (backwards compat)
+                    il
+                end
                 tether = Tether(tether_name, segs;
                     start_point=sp, end_point=ep,
+                    tether_length=tl,
                     initial_tether_length=il)
             else
                 # Route 2: auto-generation
@@ -617,6 +627,13 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                     Float64(row.init_len)
                 else
                     nothing
+                end
+                tl = if hasfield(typeof(row),
+                        :tether_length) &&
+                        !isnothing(row.tether_length)
+                    Float64(row.tether_length)
+                else
+                    il
                 end
                 # Resolve material reference if present
                 resolved = resolve_references(
@@ -642,7 +659,8 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                     start_point=sp, end_point=ep,
                     n_segments=n_seg,
                     unit_stiffness=us, unit_damping=ud,
-                    diameter=d, initial_tether_length=il)
+                    diameter=d, tether_length=tl,
+                    initial_tether_length=il)
             end
             push!(tethers, tether)
         end
@@ -659,7 +677,7 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
             # Create Winch using constructor (name, set, tethers; winch_point)
             winch = call_yaml_constructor(Winch, row,
                 [:name, :set, :tethers],
-                [:winch_point, :tether_len, :tether_vel,
+                [:winch_point, :init_vel,
                  :brake, :speed_controlled,
                  :friction_epsilon];
                 mappings=Dict(

--- a/src/yaml_loader.jl
+++ b/src/yaml_loader.jl
@@ -618,8 +618,9 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                 ul = !isnothing(tl) ? tl :
                     !isnothing(il) ? il :
                     error("Tether $tether_name: " *
-                        "init_unstretched_length or " *
-                        "init_stretched_length required")
+                        "init_unstretched_length " *
+                        "or init_stretched_length " *
+                        "is required")
                 tether = Tether(tether_name, segs, ul;
                     start_point=sp, end_point=ep,
                     stretched_length=il)
@@ -669,8 +670,9 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                 ul = !isnothing(tl) ? tl :
                     !isnothing(il) ? il :
                     error("Tether $tether_name: " *
-                        "init_unstretched_length or " *
-                        "init_stretched_length required")
+                        "init_unstretched_length " *
+                        "or init_stretched_length " *
+                        "is required")
                 tether = Tether(tether_name, ul;
                     start_point=sp, end_point=ep,
                     n_segments=n_seg,

--- a/src/yaml_loader.jl
+++ b/src/yaml_loader.jl
@@ -1114,7 +1114,7 @@ function update_yaml_from_sys_struct!(sys_struct::SystemStructure,
             # Update data rows if we know the column
             if tether_init_len_col > 0
                 dm = match(
-                    r"^(\s*-\s*\[)(\w+)(.*)", line)
+                    r"^(\s*-\s*\[)([\w-]+)(.*)", line)
                 if dm !== nothing
                     name = String(dm.captures[2])
                     if haskey(tether_init_lens, name)

--- a/test/setup_integration.jl
+++ b/test/setup_integration.jl
@@ -41,7 +41,8 @@ function extract_readme_code(heading_pattern)
     found_heading = false
     in_block = false
     code_lines = String[]
-    skip_patterns = [r"using Pkg", r"^pkg\""]
+    skip_patterns = [
+        r"using Pkg", r"^pkg\"", r"plot[!]?\(", r"sleep\("]
     for line in lines
         if !found_heading
             if occursin(heading_pattern, line)

--- a/test/test_tether_init.jl
+++ b/test/test_tether_init.jl
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Bart van de Lint
 # SPDX-License-Identifier: MPL-2.0
 
-# test_tether_init_stretched_length.jl - Tether initial length scaling tests
+# test_tether_init.jl - Tether initial length scaling tests
 #
 # Tests the Tether.init_stretched_length feature: scaling pos_w before transforms.
 # Uses Route 2 (auto-generated) tethers and YAML-specified init_stretched_length.

--- a/test/test_tether_init_len.jl
+++ b/test/test_tether_init_len.jl
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2025 Bart van de Lint
 # SPDX-License-Identifier: MPL-2.0
 
-# test_tether_init_len.jl - Tether initial length scaling tests
+# test_tether_init_stretched_length.jl - Tether initial length scaling tests
 #
-# Tests the Tether.init_len feature: scaling pos_w before transforms.
-# Uses Route 2 (auto-generated) tethers and YAML-specified init_len.
+# Tests the Tether.init_stretched_length feature: scaling pos_w before transforms.
+# Uses Route 2 (auto-generated) tethers and YAML-specified init_stretched_length.
 # All tests use reinit! directly on a SystemStructure (no ODE compilation).
 
 using Test
@@ -14,7 +14,7 @@ using KiteUtils
 using LinearAlgebra
 
 # ================================================================
-# Route 2 tether: ground→[auto mid]→top, 2 segments, init_len in YAML
+# Route 2 tether: ground→[auto mid]→top, 2 segments, init_stretched_length in YAML
 # ================================================================
 const INIT_LEN_YAML_ROUTE2 = """
 materials:
@@ -33,7 +33,7 @@ points:
        1.0, 0.0, 0.0, 0.0, 0.0]
 
 tethers:
-  headers: [name, start_point, end_point, n_segments, material, init_len]
+  headers: [name, start_point, end_point, n_segments, material, init_stretched_length]
   data:
     - [main_tether, ground, top, 2, test_mat, 200.0]
 
@@ -43,7 +43,7 @@ winches:
     - [main_winch, [main_tether], ground]
 """
 
-# Route 1 tether (explicit segments) with init_len in YAML
+# Route 1 tether (explicit segments) with init_stretched_length in YAML
 const INIT_LEN_YAML_ROUTE1 = """
 materials:
   headers: [name, youngs_modulus, density, damping_per_stiffness]
@@ -70,7 +70,7 @@ segments:
     - [s2, mid, top, 50.0, 4.0, 120000.0, 350.0, 0.0]
 
 tethers:
-  headers: [name, segment_idxs, init_len]
+  headers: [name, segment_idxs, init_stretched_length]
   data:
     - [main_tether, [s1, s2], 200.0]
 
@@ -106,7 +106,7 @@ segments:
     - [bridle, top, downstream, 10.0, 4.0, 120000.0, 350.0, 0.0]
 
 tethers:
-  headers: [name, start_point, end_point, n_segments, material, init_len]
+  headers: [name, start_point, end_point, n_segments, material, init_stretched_length]
   data:
     - [main_tether, ground, top, 2, test_mat, 200.0]
 
@@ -197,7 +197,7 @@ environment:
     profile_law: 0
 """
 
-@testset "Tether init_len Tests" begin
+@testset "Tether init_stretched_length Tests" begin
     tmpdir = mktempdir()
     write(joinpath(tmpdir, "settings.yaml"), INIT_LEN_SETTINGS)
     write(joinpath(tmpdir, "system.yaml"),
@@ -206,15 +206,15 @@ environment:
     set = Settings("system.yaml")
 
     # ================================================================
-    # Test 1: Route 2 auto-gen + YAML init_len → scale to 2×
+    # Test 1: Route 2 auto-gen + YAML init_stretched_length → scale to 2×
     # ================================================================
-    @testset "Route 2 YAML init_len: scale to 2x" begin
+    @testset "Route 2 YAML init_stretched_length: scale to 2x" begin
         yaml_path = joinpath(tmpdir, "r2_yaml.yaml")
         write(yaml_path, INIT_LEN_YAML_ROUTE2)
         sys = load_sys_struct_from_yaml(
-            yaml_path; system_name="init_len_r2_yaml", set=set)
+            yaml_path; system_name="init_stretched_length_r2_yaml", set=set)
 
-        # init_len=200 already set from YAML; no programmatic change needed
+        # init_stretched_length=200 already set from YAML; no programmatic change needed
         SymbolicAWEModels.reinit!(sys, set)
 
         mid = sys.points[:main_tether_point_1]
@@ -227,13 +227,13 @@ environment:
     end
 
     # ================================================================
-    # Test 2: Route 1 explicit segments + YAML init_len
+    # Test 2: Route 1 explicit segments + YAML init_stretched_length
     # ================================================================
-    @testset "Route 1 YAML init_len: scale to 2x" begin
+    @testset "Route 1 YAML init_stretched_length: scale to 2x" begin
         yaml_path = joinpath(tmpdir, "r1_yaml.yaml")
         write(yaml_path, INIT_LEN_YAML_ROUTE1)
         sys = load_sys_struct_from_yaml(
-            yaml_path; system_name="init_len_r1_yaml", set=set)
+            yaml_path; system_name="init_stretched_length_r1_yaml", set=set)
 
         SymbolicAWEModels.reinit!(sys, set)
 
@@ -251,7 +251,7 @@ environment:
         yaml_path = joinpath(tmpdir, "r2_downstream.yaml")
         write(yaml_path, INIT_LEN_DOWNSTREAM_ROUTE2)
         sys = load_sys_struct_from_yaml(
-            yaml_path; system_name="init_len_r2_downstream", set=set)
+            yaml_path; system_name="init_stretched_length_r2_downstream", set=set)
 
         SymbolicAWEModels.reinit!(sys, set)
 
@@ -266,7 +266,7 @@ environment:
         yaml_path = joinpath(tmpdir, "r2_loop.yaml")
         write(yaml_path, INIT_LEN_LOOP_ROUTE2)
         sys = load_sys_struct_from_yaml(
-            yaml_path; system_name="init_len_r2_loop", set=set)
+            yaml_path; system_name="init_stretched_length_r2_loop", set=set)
 
         sys.tethers[:main_tether].init_stretched_len = 200.0
         @test_throws ErrorException SymbolicAWEModels.reinit!(sys, set)
@@ -278,7 +278,7 @@ environment:
     @testset "Idempotency" begin
         yaml_path = joinpath(tmpdir, "r2_yaml.yaml")
         sys = load_sys_struct_from_yaml(
-            yaml_path; system_name="init_len_r2_idem", set=set)
+            yaml_path; system_name="init_stretched_length_r2_idem", set=set)
 
         SymbolicAWEModels.reinit!(sys, set)
         mid_pos = copy(sys.points[:main_tether_point_1].pos_w)

--- a/test/test_tether_init_len.jl
+++ b/test/test_tether_init_len.jl
@@ -140,9 +140,9 @@ segments:
     - [back_loop, top, ground, 100.0, 4.0, 120000.0, 350.0, 0.0]
 
 tethers:
-  headers: [name, start_point, end_point, n_segments, material]
+  headers: [name, start_point, end_point, n_segments, material, init_unstretched_length]
   data:
-    - [main_tether, ground, top, 2, test_mat]
+    - [main_tether, ground, top, 2, test_mat, 100.0]
 
 winches:
   headers: [name, tether_idxs, winch_point]

--- a/test/test_tether_init_len.jl
+++ b/test/test_tether_init_len.jl
@@ -220,7 +220,7 @@ environment:
         mid = sys.points[:main_tether_point_1]
         @test mid.pos_w ≈ KVec3(0, 0, -100)
         @test sys.points[:top].pos_w ≈ KVec3(0, 0, -200)
-        @test sys.winches[:main_winch].tether_len ≈ 200.0
+        @test sys.tethers[:main_tether].len ≈ 200.0
         # pos_cad unchanged
         @test mid.pos_cad ≈ KVec3(0, 0, -50)
         @test sys.points[:top].pos_cad ≈ KVec3(0, 0, -100)
@@ -268,7 +268,7 @@ environment:
         sys = load_sys_struct_from_yaml(
             yaml_path; system_name="init_len_r2_loop", set=set)
 
-        sys.tethers[:main_tether].init_len = 200.0
+        sys.tethers[:main_tether].init_stretched_len = 200.0
         @test_throws ErrorException SymbolicAWEModels.reinit!(sys, set)
     end
 

--- a/test/test_tether_winch.jl
+++ b/test/test_tether_winch.jl
@@ -367,7 +367,7 @@ environment:
 
         # Route 2: auto-generate 4 segments between mass
         # and anchor
-        tethers = [Tether(:line;
+        tethers = [Tether(:line, 100.0;
             start_point=:mass, end_point=:anchor,
             n_segments=4)]
         winches = [Winch(:winch, set, [:line];
@@ -471,7 +471,7 @@ environment:
             Segment(:seg, :top, :bot, 50000.0, 500.0,
                     0.001; l0=50.0)
         ]
-        tethers = [Tether(:free_tether, [:seg])]
+        tethers = [Tether(:free_tether, [:seg], 50.0)]
         transforms = [
             Transform(:tf, deg2rad(-80.0), 0.0, 0.0;
                 base_pos=[0, 0, 0], base_point=:bot,

--- a/test/test_tether_winch.jl
+++ b/test/test_tether_winch.jl
@@ -40,9 +40,9 @@ segments:
        0.0, 0.0, 0.0]
 
 tethers:
-  headers: [name, segment_idxs]
+  headers: [name, segment_idxs, init_unstretched_length]
   data:
-    - [main_tether, [tether_seg]]
+    - [main_tether, [tether_seg], 50.0]
 
 winches:
   headers: [name, tether_idxs, winch_point]

--- a/test/test_tether_winch.jl
+++ b/test/test_tether_winch.jl
@@ -140,7 +140,7 @@ environment:
             next_step!(sam; set_values=[tau_motor],
                        dt=0.001, vsm_interval=0)
         end
-        @test abs(tether.vel) < 1e-10
+        @test abs(winch.vel) < 1e-10
     end
 
     # ============================================================
@@ -168,7 +168,7 @@ environment:
             end
 
             # v(t) = a*t, so a = v / t
-            a_measured = tether.vel / (n_steps * dt)
+            a_measured = winch.vel / (n_steps * dt)
             a_expected = (r / n) * tau_motor / I_test
 
             @test a_measured ≈ a_expected rtol=0.05
@@ -201,7 +201,7 @@ environment:
                 next_step!(sam; set_values=[tau_motor],
                            dt=dt, vsm_interval=0)
             end
-            v0 = tether.vel
+            v0 = winch.vel
 
             # Measure acceleration over next steps
             n_meas = 20
@@ -209,7 +209,7 @@ environment:
                 next_step!(sam; set_values=[tau_motor],
                            dt=dt, vsm_interval=0)
             end
-            v1 = tether.vel
+            v1 = winch.vel
 
             a_measured = (v1 - v0) / (n_meas * dt)
             a_expected = (r / n) / I *
@@ -251,7 +251,7 @@ environment:
             end
 
             v_expected = tau_motor * n / (c_vf_test * r)
-            @test tether.vel ≈ v_expected rtol=0.05
+            @test winch.vel ≈ v_expected rtol=0.05
         end
     end
 

--- a/test/test_tether_winch.jl
+++ b/test/test_tether_winch.jl
@@ -118,6 +118,7 @@ environment:
     init!(sam; remake=true, prn=false)
 
     winch = sam.sys_struct.winches[:main_winch]
+    tether = sam.sys_struct.tethers[:main_tether]
     seg = sam.sys_struct.segments[:tether_seg]
     r = winch.drum_radius   # 0.1 m
     n = winch.gear_ratio     # 1.0
@@ -139,7 +140,7 @@ environment:
             next_step!(sam; set_values=[tau_motor],
                        dt=0.001, vsm_interval=0)
         end
-        @test abs(winch.tether_vel) < 1e-10
+        @test abs(tether.vel) < 1e-10
     end
 
     # ============================================================
@@ -167,7 +168,7 @@ environment:
             end
 
             # v(t) = a*t, so a = v / t
-            a_measured = winch.tether_vel / (n_steps * dt)
+            a_measured = tether.vel / (n_steps * dt)
             a_expected = (r / n) * tau_motor / I_test
 
             @test a_measured ≈ a_expected rtol=0.05
@@ -200,7 +201,7 @@ environment:
                 next_step!(sam; set_values=[tau_motor],
                            dt=dt, vsm_interval=0)
             end
-            v0 = winch.tether_vel
+            v0 = tether.vel
 
             # Measure acceleration over next steps
             n_meas = 20
@@ -208,7 +209,7 @@ environment:
                 next_step!(sam; set_values=[tau_motor],
                            dt=dt, vsm_interval=0)
             end
-            v1 = winch.tether_vel
+            v1 = tether.vel
 
             a_measured = (v1 - v0) / (n_meas * dt)
             a_expected = (r / n) / I *
@@ -250,7 +251,7 @@ environment:
             end
 
             v_expected = tau_motor * n / (c_vf_test * r)
-            @test winch.tether_vel ≈ v_expected rtol=0.05
+            @test tether.vel ≈ v_expected rtol=0.05
         end
     end
 
@@ -331,7 +332,7 @@ environment:
         end
 
         steady = calc_steady_torque(sam)
-        @test sam.sys_struct.winches[1].tether_acc ≈ 0.0 atol=0.01
+        @test sam.sys_struct.winches[1].acc ≈ 0.0 atol=0.01
         @test steady[1] ≈ tau_motor rtol=0.01
 
         println(


### PR DESCRIPTION
**Summary:**
- Move `tether_len` ODE state from per-winch to per-tether, enabling winchless tethers to participate in the `l0` equation
- Move `tether_vel`/`tether_acc` → `winch_vel`/`winch_acc` (per-winch, since velocity/acceleration come from motor dynamics)
- Add `len`, `init_len`, `init_stretched_len` fields to `Tether`; add `vel` to `Winch`; remove `tether_len`, `tether_vel`, `tether_acc` from `Winch`
- Winchless tethers get `D(tether_len) ~ 0` (constant length); winched tethers get `D(tether_len) ~ winch_vel`
- All tether segments use `l0 = tether_len / n_segments` (unified equation)
- Sync `segment.l0` from integrator via `get_segment_state`
- Add `tether_length` kwarg to Tether constructors for setting unstretched rope length independently from `initial_tether_length` (point positioning)
- Rename `apply_tether_init_lens!` → `apply_tether_init_stretched_lens!`
- Simplify `copy!` tether branch (remove force/stiffness estimation)
- Remove dead `autocalc_tether_len` function
- Fix type annotation bug in `coupled_2plate_kite_linear_vsm.jl`

**Motivation:**
Previously, `tether_len`/`tether_vel` were indexed by winch, so only winch-connected tethers had their segment `l0` driven by the ODE. Now `tether_len` is per-tether (all tethers get dynamic `l0`), while `winch_vel` stays per-winch (one motor drives all connected tethers at the same speed). This enables winchless route-2 tethers, slack/sag scenarios (`l0 > geometric_distance`), and different lengths for multiple tethers on the same winch.