### PR TITLE
Separate out aero to component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # CHANGELOG
 
+## Unreleased
+
+### Added
+- Swappable per-wing aero components, winch-style. Each wing carries an
+  `aero_model` builder (`(sys_struct, wing_idx; name) -> System`) selected by
+  `aero_mode`. The built-in modes map to `default_aero_none` /
+  `default_aero_direct` / `default_aero_linearized`; the new `AERO_CUSTOM`
+  value plugs in a user builder. Components connect at a fixed body-frame
+  contract per `dynamics_type` (RIGID: `va`, `rho`, `R_b_w`, `omega`, `twist`,
+  `twist_vel` → `force`, `moment`, `twist_moment`; PARTICLE: per-point
+  `pos`/`vel` → `force`), validated by `validate_aero_component`.
+- `has_custom_component(sys_struct)`: `init!` now defaults `remake` to rebuild
+  automatically when a custom winch/aero component is present (their equations
+  are not captured by the model hash).
+
+### Changed
+- `vsm_eqs.jl` is now a thin winch-style wiring layer: it instantiates each
+  non-plate wing's `aero_model`, binds the body-frame inputs, and reads the
+  outputs. The aero components are attached as subsystems alongside the winch
+  subsystems. The generated RHS stays allocation-free (`test_bench.jl`).
+- `nameof(wing.aero_model)` is folded into the model hash.
+
 ## v0.11.1 06-06-2026
 
 ### Added

--- a/bin/run_julia
+++ b/bin/run_julia
@@ -27,7 +27,7 @@ fi
 if [[ $# -gt 0 ]]; then
     JULIA_ARGS=("$@")
 else
-    JULIA_ARGS=(-i -e 'using KiteUtils: menu')
+    JULIA_ARGS=()
 fi
 
 THREADS="auto"

--- a/docs/src/private_functions.md
+++ b/docs/src/private_functions.md
@@ -67,6 +67,7 @@ SymbolicAWEModels.load_serialized_model!
 SymbolicAWEModels.maybe_create_lin_prob!
 SymbolicAWEModels.maybe_create_control_functions!
 SymbolicAWEModels.maybe_create_prob!
+SymbolicAWEModels.has_custom_component
 SymbolicAWEModels.generate_control_funcs
 SymbolicAWEModels.generate_lin_getters
 SymbolicAWEModels.generate_prob_getters

--- a/docs/src/vsm_coupling.md
+++ b/docs/src/vsm_coupling.md
@@ -198,7 +198,48 @@ without aerodynamic coupling.
 | **PARTICLE_DYNAMICS** | `AERO_DIRECT` | `AERO_DIRECT`, `AERO_NONE` |
 
 `PARTICLE_DYNAMICS` + `AERO_LINEARIZED` is not yet implemented (raises an
-error at runtime).
+error during model build).
+
+## Swappable aero components (`AERO_CUSTOM`)
+
+Each wing carries an `aero_model` builder, exactly like a winch's
+[`Winch`](@ref) `model` field. The built-in `aero_mode`s select a default
+builder (`default_aero_none` / `default_aero_direct` /
+`default_aero_linearized`); to plug in your own aerodynamics, pass a builder
+and set `aero_mode = AERO_CUSTOM`:
+
+```julia
+VSMWing(name, set, groups, vsm_set;
+        aero_mode = AERO_CUSTOM, aero_model = my_aero_builder)
+```
+
+The builder has the signature `my_aero_builder(sys_struct, wing_idx; name)`
+and returns a `System` whose connectors are fixed by the wing's
+`dynamics_type` (all quantities in the wing **body frame**):
+
+- **`RIGID_DYNAMICS`** (`ng = length(wing.group_idxs)`):
+  - inputs: `va[1:3]`, `rho`, `R_b_w[1:3,1:3]`, `omega[1:3]`,
+    and — when `ng > 0` — `twist[1:ng]`, `twist_vel[1:ng]`
+  - outputs: `force[1:3]`, `moment[1:3]`, `twist_moment[1:ng]`
+- **`PARTICLE_DYNAMICS`** (`np` = number of `WING` points):
+  - inputs: `point_pos[1:3,1:np]`, `point_vel[1:3,1:np]`
+  - outputs: `point_force[1:3,1:np]`
+
+The wiring layer drives the inputs and reads the outputs; the component is
+flattened by `mtkcompile`, so its connectors become inlined unknowns (no
+array crosses a registered-function boundary). `validate_aero_component`
+checks the contract at build time.
+
+Custom builder equations are **not captured by the model hash**, so `init!`
+defaults to `remake=true` whenever a custom winch/aero component is present
+(see [`has_custom_component`](@ref)).
+
+!!! note "Zero-allocation RHS"
+    The built-in modes generate an allocation-free ODE RHS (asserted by
+    `test_bench.jl`). A custom component is not tested in-package; to keep the
+    RHS allocation-free, its equations must stay scalar/zero-alloc (a registered
+    function with an array argument or return value will allocate). Check with
+    `validate_rhs_allocs(sam; max_bytes=0, diagnose=true)`.
 
 ## Aligning aero sections to structure
 

--- a/docs/src/vsm_coupling.md
+++ b/docs/src/vsm_coupling.md
@@ -232,7 +232,7 @@ checks the contract at build time.
 
 Custom builder equations are **not captured by the model hash**, so `init!`
 defaults to `remake=true` whenever a custom winch/aero component is present
-(see [`has_custom_component`](@ref)).
+(via `has_custom_component`).
 
 !!! note "Zero-allocation RHS"
     The built-in modes generate an allocation-free ODE RHS (asserted by

--- a/src/generate_system/accessors.jl
+++ b/src/generate_system/accessors.jl
@@ -252,6 +252,10 @@ get_brake(sys::SystemStructure, idx::Int64) =
     sys.winches[idx].brake
 @register_symbolic get_brake(
     sys::SystemStructure, idx::Int64)
+get_speed_controlled(sys::SystemStructure, idx::Int64) =
+    sys.winches[idx].speed_controlled
+@register_symbolic get_speed_controlled(
+    sys::SystemStructure, idx::Int64)
 get_winch_gear_ratio(sys::SystemStructure, idx::Int64) =
     sys.winches[idx].gear_ratio
 @register_symbolic get_winch_gear_ratio(

--- a/src/generate_system/aero_components.jl
+++ b/src/generate_system/aero_components.jl
@@ -7,14 +7,14 @@
 # (see `resolve_aero_model`). Each builder returns a `System` whose
 # connectors are fixed by the wing's `dynamics_type`:
 #
-#   RIGID_DYNAMICS (ng = length(wing.group_idxs)):
+#   RIGID_DYNAMICS (num_groups = length(wing.group_idxs)):
 #     inputs:  va[1:3], rho, R_b_w[1:3,1:3], omega[1:3],
-#              twist[1:ng], twist_vel[1:ng]            (ng > 0 only)
-#     outputs: force[1:3], moment[1:3], twist_moment[1:ng]
+#              twist[1:num_groups], twist_vel[1:num_groups]
+#     outputs: force[1:3], moment[1:3], twist_moment[1:num_groups]
 #
-#   PARTICLE_DYNAMICS (np = number of WING points):
-#     inputs:  point_pos[1:3,1:np], point_vel[1:3,1:np]
-#     outputs: point_force[1:3,1:np]
+#   PARTICLE_DYNAMICS (num_points = number of WING points):
+#     inputs:  point_pos[1:3,1:num_points], point_vel[1:3,1:num_points]
+#     outputs: point_force[1:3,1:num_points]
 #
 # Everything is in the wing body frame. The wiring layer (vsm_eqs!)
 # drives the inputs and reads the outputs.
@@ -28,7 +28,7 @@
 # the wiring layer to bind, the same way the winch component lists
 # `len`.
 
-function _rigid_aero_connectors(ng::Int)
+function _rigid_aero_connectors(num_groups::Int)
     @variables begin
         va(t)[1:3]
         rho(t)
@@ -37,8 +37,8 @@ function _rigid_aero_connectors(ng::Int)
         force(t)[1:3]
         moment(t)[1:3]
     end
-    if ng > 0
-        @variables twist(t)[1:ng] twist_vel(t)[1:ng] twist_moment(t)[1:ng]
+    if num_groups > 0
+        @variables twist(t)[1:num_groups] twist_vel(t)[1:num_groups] twist_moment(t)[1:num_groups]
     else
         twist = nothing
         twist_vel = nothing
@@ -48,27 +48,30 @@ function _rigid_aero_connectors(ng::Int)
             twist, twist_vel, twist_moment)
 end
 
-function _rigid_unknowns(c)
-    vars = Any[c.va, c.rho, c.R_b_w, c.omega, c.force, c.moment]
-    c.twist === nothing ||
-        append!(vars, Any[c.twist, c.twist_vel, c.twist_moment])
+function _rigid_unknowns(connectors)
+    vars = Any[connectors.va, connectors.rho, connectors.R_b_w,
+               connectors.omega, connectors.force, connectors.moment]
+    connectors.twist === nothing ||
+        append!(vars, Any[connectors.twist, connectors.twist_vel,
+                          connectors.twist_moment])
     return vars
 end
 
-function _particle_aero_connectors(np::Int)
+function _particle_aero_connectors(num_points::Int)
     @variables begin
-        point_pos(t)[1:3, 1:np]
-        point_vel(t)[1:3, 1:np]
-        point_force(t)[1:3, 1:np]
+        point_pos(t)[1:3, 1:num_points]
+        point_vel(t)[1:3, 1:num_points]
+        point_force(t)[1:3, 1:num_points]
     end
     return (; point_pos, point_vel, point_force)
 end
 
-_particle_unknowns(c) = Any[c.point_pos, c.point_vel, c.point_force]
+_particle_unknowns(connectors) =
+    Any[connectors.point_pos, connectors.point_vel, connectors.point_force]
 
 function _wing_points(sys_struct, wing)
-    return [p for p in sys_struct.points
-            if p.type == WING && p.wing_idx == wing.idx]
+    return [point for point in sys_struct.points
+            if point.type == WING && point.wing_idx == wing.idx]
 end
 
 # ==================== NoAero ==================== #
@@ -79,18 +82,20 @@ function default_aero_none(sys_struct, wing_idx; name)
     wing = sys_struct.wings[wing_idx]
 
     if wing.dynamics_type == PARTICLE_DYNAMICS
-        np = length(_wing_points(sys_struct, wing))
-        c = _particle_aero_connectors(np)
-        eqs = vec(collect(c.point_force)) .~ 0
-        return System(eqs, t, _particle_unknowns(c), [psys]; name)
+        num_points = length(_wing_points(sys_struct, wing))
+        connectors = _particle_aero_connectors(num_points)
+        eqs = vec(collect(connectors.point_force)) .~ 0
+        return System(eqs, t, _particle_unknowns(connectors), [psys]; name)
+    elseif wing.dynamics_type == RIGID_DYNAMICS
+        num_groups = length(wing.group_idxs)
+        connectors = _rigid_aero_connectors(num_groups)
+        eqs = [collect(connectors.force) .~ 0
+               collect(connectors.moment) .~ 0]
+        num_groups > 0 && (eqs = [eqs; collect(connectors.twist_moment) .~ 0])
+        return System(eqs, t, _rigid_unknowns(connectors), [psys]; name)
+    else
+        error("Unknown dynamics_type $(wing.dynamics_type) for wing $wing_idx.")
     end
-
-    ng = length(wing.group_idxs)
-    c = _rigid_aero_connectors(ng)
-    eqs = [collect(c.force) .~ 0
-           collect(c.moment) .~ 0]
-    ng > 0 && (eqs = [eqs; collect(c.twist_moment) .~ 0])
-    return System(eqs, t, _rigid_unknowns(c), [psys]; name)
 end
 
 # ==================== DiscreteAero (AERO_DIRECT) ==================== #
@@ -102,32 +107,33 @@ function default_aero_direct(sys_struct, wing_idx; name)
 
     if wing.dynamics_type == PARTICLE_DYNAMICS
         points = _wing_points(sys_struct, wing)
-        np = length(points)
-        c = _particle_aero_connectors(np)
+        num_points = length(points)
+        connectors = _particle_aero_connectors(num_points)
         eqs = Equation[]
-        for (k, point) in enumerate(points)
+        for (point_num, point) in enumerate(points)
             eqs = [eqs
-                   collect(c.point_force[:, k]) .~
+                   collect(connectors.point_force[:, point_num]) .~
                        [get_point_aero_force(psys, point.idx, i)
                         for i in 1:3]]
         end
-        return System(eqs, t, _particle_unknowns(c), [psys]; name)
+        return System(eqs, t, _particle_unknowns(connectors), [psys]; name)
+    elseif wing.dynamics_type == RIGID_DYNAMICS
+        groups = sys_struct.groups
+        num_groups = length(wing.group_idxs)
+        connectors = _rigid_aero_connectors(num_groups)
+        eqs = [collect(connectors.force) .~
+                   [get_aero_force_override(psys, wing.idx, i) for i in 1:3]
+               collect(connectors.moment) .~
+                   [get_aero_moment_override(psys, wing.idx, i) for i in 1:3]]
+        for (group_pos, group_idx) in enumerate(wing.group_idxs)
+            rhs = isempty(groups[group_idx].unrefined_section_idxs) ? 0 :
+                get_group_moment_override(psys, wing.idx, Int64(group_idx))
+            eqs = [eqs; connectors.twist_moment[group_pos] ~ rhs]
+        end
+        return System(eqs, t, _rigid_unknowns(connectors), [psys]; name)
+    else
+        error("Unknown dynamics_type $(wing.dynamics_type) for wing $wing_idx.")
     end
-
-    groups = sys_struct.groups
-    ng = length(wing.group_idxs)
-    c = _rigid_aero_connectors(ng)
-    w = wing.idx
-    eqs = [collect(c.force) .~
-               [get_aero_force_override(psys, w, i) for i in 1:3]
-           collect(c.moment) .~
-               [get_aero_moment_override(psys, w, i) for i in 1:3]]
-    for (gi, gidx) in enumerate(wing.group_idxs)
-        rhs = isempty(groups[gidx].unrefined_section_idxs) ? 0 :
-            get_group_moment_override(psys, w, Int64(gidx))
-        eqs = [eqs; c.twist_moment[gi] ~ rhs]
-    end
-    return System(eqs, t, _rigid_unknowns(c), [psys]; name)
 end
 
 # ==================== LinearizedAero ==================== #
@@ -144,30 +150,29 @@ function default_aero_linearized(sys_struct, wing_idx; name)
         "AERO_LINEARIZED wing $wing_idx is not a VSMWing.")
 
     groups = sys_struct.groups
-    ng = length(wing.group_idxs)
-    ny = length(wing.aero_y)
-    nx = length(wing.aero_x)
-    w = wing.idx
+    num_groups = length(wing.group_idxs)
+    num_aero_inputs = length(wing.aero_y)
     area = wing.vsm_aero.projected_area
     c_ref = wing.vsm_aero.c_ref
 
-    c = _rigid_aero_connectors(ng)
-    @variables aero_input(t)[1:ny]
+    connectors = _rigid_aero_connectors(num_groups)
+    @variables aero_input(t)[1:num_aero_inputs]
 
-    va = collect(c.va)
-    omega = collect(c.omega)
-    drag_dir = collect(va ./ smooth_norm(va))
+    apparent_wind = collect(connectors.va)
+    omega = collect(connectors.omega)
+    drag_dir = collect(apparent_wind ./ smooth_norm(apparent_wind))
     alpha = atan(drag_dir[3], drag_dir[1])
     beta = atan(drag_dir[2], smooth_norm((drag_dir[1], drag_dir[3])))
 
-    twist_inputs = ng > 0 ? collect(c.twist) : Num[]
+    twist_inputs = num_groups > 0 ? collect(connectors.twist) : Num[]
     input_rhs = [alpha; beta; omega[1]; omega[2]; omega[3]; twist_inputs]
 
-    delta(iy) = aero_input[iy] - get_aero_y(psys, w, iy)
-    coeff(ix) = get_aero_x(psys, w, ix) +
-        sum(get_aero_jac(psys, w, ix, iy) * delta(iy) for iy in 1:ny)
+    delta(input_idx) = aero_input[input_idx] - get_aero_y(psys, wing.idx, input_idx)
+    coeff(output_idx) = get_aero_x(psys, wing.idx, output_idx) +
+        sum(get_aero_jac(psys, wing.idx, output_idx, input_idx) * delta(input_idx)
+            for input_idx in 1:num_aero_inputs)
 
-    q_inf = 0.5 * c.rho * (va ⋅ va)
+    q_inf = 0.5 * connectors.rho * (apparent_wind ⋅ apparent_wind)
     qA = q_inf * area
     CL = coeff(1)
     CD = coeff(2)
@@ -176,22 +181,23 @@ function default_aero_linearized(sys_struct, wing_idx; name)
     crossed = collect(drag_dir × [0.0, 1.0, 0.0])
     lift_dir = collect(crossed ./ smooth_norm(crossed))
     side_dir = collect(lift_dir × drag_dir)
-    drag_frac = get_drag_frac(psys, w)
+    drag_frac = get_drag_frac(psys, wing.idx)
 
     force_rhs = collect(qA * (CL * lift_dir +
         CD * drag_frac * drag_dir + CS * side_dir))
     moment_rhs = [qA * c_ref * coeff(3 + i) for i in 1:3]
 
     eqs = [collect(aero_input) .~ input_rhs
-           collect(c.force) .~ force_rhs
-           collect(c.moment) .~ moment_rhs]
-    for gi in 1:ng
-        isempty(groups[wing.group_idxs[gi]].unrefined_section_idxs) ?
-            (eqs = [eqs; c.twist_moment[gi] ~ 0]) :
-            (eqs = [eqs; c.twist_moment[gi] ~ qA * c_ref * coeff(6 + gi)])
+           collect(connectors.force) .~ force_rhs
+           collect(connectors.moment) .~ moment_rhs]
+    for group_pos in 1:num_groups
+        isempty(groups[wing.group_idxs[group_pos]].unrefined_section_idxs) ?
+            (eqs = [eqs; connectors.twist_moment[group_pos] ~ 0]) :
+            (eqs = [eqs; connectors.twist_moment[group_pos] ~
+                qA * c_ref * coeff(6 + group_pos)])
     end
 
-    vars = _rigid_unknowns(c)
+    vars = _rigid_unknowns(connectors)
     push!(vars, aero_input)
     return System(eqs, t, vars, [psys]; name)
 end

--- a/src/generate_system/aero_components.jl
+++ b/src/generate_system/aero_components.jl
@@ -1,0 +1,223 @@
+# Copyright (c) 2025 Bart van de Lint
+# SPDX-License-Identifier: LGPL-3.0-only
+
+# Aero coupling components (winch-style swappable subsystems).
+#
+# A wing carries an `aero_model` builder selected by `aero_mode`
+# (see `resolve_aero_model`). Each builder returns a `System` whose
+# connectors are fixed by the wing's `dynamics_type`:
+#
+#   RIGID_DYNAMICS (ng = length(wing.group_idxs)):
+#     inputs:  va[1:3], rho, R_b_w[1:3,1:3], omega[1:3],
+#              twist[1:ng], twist_vel[1:ng]            (ng > 0 only)
+#     outputs: force[1:3], moment[1:3], twist_moment[1:ng]
+#
+#   PARTICLE_DYNAMICS (np = number of WING points):
+#     inputs:  point_pos[1:3,1:np], point_vel[1:3,1:np]
+#     outputs: point_force[1:3,1:np]
+#
+# Everything is in the wing body frame. The wiring layer (vsm_eqs!)
+# drives the inputs and reads the outputs.
+
+_flatten_vars(x) = x === nothing ? Num[] : vec(collect(x))
+
+# ==================== connector declarations ==================== #
+
+function _rigid_aero_connectors(ng::Int)
+    @variables begin
+        va(t)[1:3]
+        rho(t)
+        R_b_w(t)[1:3, 1:3]
+        omega(t)[1:3]
+        force(t)[1:3]
+        moment(t)[1:3]
+    end
+    if ng > 0
+        @variables twist(t)[1:ng] twist_vel(t)[1:ng] twist_moment(t)[1:ng]
+    else
+        twist = nothing
+        twist_vel = nothing
+        twist_moment = nothing
+    end
+    return (; va, rho, R_b_w, omega, force, moment,
+            twist, twist_vel, twist_moment)
+end
+
+function _rigid_unknowns(c)
+    return [_flatten_vars(c.va); c.rho; _flatten_vars(c.R_b_w);
+            _flatten_vars(c.omega); _flatten_vars(c.force);
+            _flatten_vars(c.moment); _flatten_vars(c.twist);
+            _flatten_vars(c.twist_vel); _flatten_vars(c.twist_moment)]
+end
+
+function _particle_aero_connectors(np::Int)
+    @variables begin
+        point_pos(t)[1:3, 1:np]
+        point_vel(t)[1:3, 1:np]
+        point_force(t)[1:3, 1:np]
+    end
+    return (; point_pos, point_vel, point_force)
+end
+
+_particle_unknowns(c) =
+    [_flatten_vars(c.point_pos); _flatten_vars(c.point_vel);
+     _flatten_vars(c.point_force)]
+
+function _wing_points(sys_struct, wing)
+    return [p for p in sys_struct.points
+            if p.type == WING && p.wing_idx == wing.idx]
+end
+
+# ==================== NoAero ==================== #
+
+function default_aero_none(sys_struct, wing_idx; name)
+    SST = typeof(sys_struct)
+    @parameters (psys::SST = sys_struct), [tunable = false]
+    wing = sys_struct.wings[wing_idx]
+
+    if wing.dynamics_type == PARTICLE_DYNAMICS
+        np = length(_wing_points(sys_struct, wing))
+        c = _particle_aero_connectors(np)
+        eqs = [collect(c.point_force) .~ 0]
+        return System(eqs, t, _particle_unknowns(c), [psys]; name)
+    end
+
+    ng = length(wing.group_idxs)
+    c = _rigid_aero_connectors(ng)
+    eqs = [collect(c.force) .~ 0
+           collect(c.moment) .~ 0]
+    ng > 0 && (eqs = [eqs; collect(c.twist_moment) .~ 0])
+    return System(eqs, t, _rigid_unknowns(c), [psys]; name)
+end
+
+# ==================== DiscreteAero (AERO_DIRECT) ==================== #
+
+function default_aero_direct(sys_struct, wing_idx; name)
+    SST = typeof(sys_struct)
+    @parameters (psys::SST = sys_struct), [tunable = false]
+    wing = sys_struct.wings[wing_idx]
+
+    if wing.dynamics_type == PARTICLE_DYNAMICS
+        points = _wing_points(sys_struct, wing)
+        np = length(points)
+        c = _particle_aero_connectors(np)
+        eqs = Equation[]
+        for (k, point) in enumerate(points)
+            eqs = [eqs
+                   collect(c.point_force[:, k]) .~
+                       [get_point_aero_force(psys, point.idx, i)
+                        for i in 1:3]]
+        end
+        return System(eqs, t, _particle_unknowns(c), [psys]; name)
+    end
+
+    groups = sys_struct.groups
+    ng = length(wing.group_idxs)
+    c = _rigid_aero_connectors(ng)
+    w = wing.idx
+    eqs = [collect(c.force) .~
+               [get_aero_force_override(psys, w, i) for i in 1:3]
+           collect(c.moment) .~
+               [get_aero_moment_override(psys, w, i) for i in 1:3]]
+    for (gi, gidx) in enumerate(wing.group_idxs)
+        rhs = isempty(groups[gidx].unrefined_section_idxs) ? 0 :
+            get_group_moment_override(psys, w, Int64(gidx))
+        eqs = [eqs; c.twist_moment[gi] ~ rhs]
+    end
+    return System(eqs, t, _rigid_unknowns(c), [psys]; name)
+end
+
+# ==================== LinearizedAero ==================== #
+
+function default_aero_linearized(sys_struct, wing_idx; name)
+    SST = typeof(sys_struct)
+    @parameters (psys::SST = sys_struct), [tunable = false]
+    wing = sys_struct.wings[wing_idx]
+
+    wing.dynamics_type == PARTICLE_DYNAMICS && error(
+        "AERO_LINEARIZED is not supported for PARTICLE_DYNAMICS " *
+        "wings (wing $wing_idx); use AERO_DIRECT or a custom model.")
+    wing isa VSMWing || error(
+        "AERO_LINEARIZED wing $wing_idx is not a VSMWing.")
+
+    groups = sys_struct.groups
+    ng = length(wing.group_idxs)
+    ny = length(wing.aero_y)
+    nx = length(wing.aero_x)
+    w = wing.idx
+    area = wing.vsm_aero.projected_area
+    c_ref = wing.vsm_aero.c_ref
+
+    c = _rigid_aero_connectors(ng)
+    @variables aero_input(t)[1:ny]
+
+    va = collect(c.va)
+    omega = collect(c.omega)
+    drag_dir = collect(va ./ smooth_norm(va))
+    alpha = atan(drag_dir[3], drag_dir[1])
+    beta = atan(drag_dir[2], smooth_norm((drag_dir[1], drag_dir[3])))
+
+    twist_inputs = ng > 0 ? collect(c.twist) : Num[]
+    input_rhs = [alpha; beta; omega[1]; omega[2]; omega[3]; twist_inputs]
+
+    delta(iy) = aero_input[iy] - get_aero_y(psys, w, iy)
+    coeff(ix) = get_aero_x(psys, w, ix) +
+        sum(get_aero_jac(psys, w, ix, iy) * delta(iy) for iy in 1:ny)
+
+    q_inf = 0.5 * c.rho * (va ⋅ va)
+    qA = q_inf * area
+    CL = coeff(1)
+    CD = coeff(2)
+    CS = coeff(3)
+
+    crossed = collect(drag_dir × [0.0, 1.0, 0.0])
+    lift_dir = collect(crossed ./ smooth_norm(crossed))
+    side_dir = collect(lift_dir × drag_dir)
+    drag_frac = get_drag_frac(psys, w)
+
+    force_rhs = collect(qA * (CL * lift_dir +
+        CD * drag_frac * drag_dir + CS * side_dir))
+    moment_rhs = [qA * c_ref * coeff(3 + i) for i in 1:3]
+
+    eqs = [collect(aero_input) .~ input_rhs
+           collect(c.force) .~ force_rhs
+           collect(c.moment) .~ moment_rhs]
+    for gi in 1:ng
+        isempty(groups[wing.group_idxs[gi]].unrefined_section_idxs) ?
+            (eqs = [eqs; c.twist_moment[gi] ~ 0]) :
+            (eqs = [eqs; c.twist_moment[gi] ~ qA * c_ref * coeff(6 + gi)])
+    end
+
+    unknowns = [_rigid_unknowns(c); collect(aero_input)]
+    return System(eqs, t, unknowns, [psys]; name)
+end
+
+# ==================== PlateAero (not via component path) ==================== #
+
+default_aero_plate(sys_struct, wing_idx; name) = error(
+    "PlateWing aerodynamics use plate_eqs!, not the aero component path.")
+
+# ==================== validation ==================== #
+
+"""
+    validate_aero_component(subsys, wing)
+
+Check that `subsys` (built by `wing.aero_model`) exposes the
+connector contract for the wing's `dynamics_type`.
+"""
+function validate_aero_component(subsys, wing)
+    if wing.dynamics_type == RIGID_DYNAMICS
+        required = Symbol[:va, :rho, :R_b_w, :omega, :force, :moment]
+        length(wing.group_idxs) > 0 &&
+            append!(required, [:twist, :twist_vel, :twist_moment])
+    else
+        required = Symbol[:point_pos, :point_vel, :point_force]
+    end
+    required_str = join(required, ", ")
+    for con in required
+        hasproperty(subsys, con) || error(
+            "Wing $(wing.name): aero component is missing required " *
+            "connector `$con`. Required: $required_str.")
+    end
+    return nothing
+end

--- a/src/generate_system/aero_components.jl
+++ b/src/generate_system/aero_components.jl
@@ -19,9 +19,14 @@
 # Everything is in the wing body frame. The wiring layer (vsm_eqs!)
 # drives the inputs and reads the outputs.
 
-_flatten_vars(x) = x === nothing ? Num[] : vec(collect(x))
-
 # ==================== connector declarations ==================== #
+#
+# Connectors are declared as array variables and passed to `System`
+# unflattened — MTK accepts array (and scalar) variables as unknowns.
+# Listing them explicitly is required so that input connectors with no
+# internal equation (a built-in ignores most of them) still exist for
+# the wiring layer to bind, the same way the winch component lists
+# `len`.
 
 function _rigid_aero_connectors(ng::Int)
     @variables begin
@@ -44,10 +49,10 @@ function _rigid_aero_connectors(ng::Int)
 end
 
 function _rigid_unknowns(c)
-    return [_flatten_vars(c.va); c.rho; _flatten_vars(c.R_b_w);
-            _flatten_vars(c.omega); _flatten_vars(c.force);
-            _flatten_vars(c.moment); _flatten_vars(c.twist);
-            _flatten_vars(c.twist_vel); _flatten_vars(c.twist_moment)]
+    vars = Any[c.va, c.rho, c.R_b_w, c.omega, c.force, c.moment]
+    c.twist === nothing ||
+        append!(vars, Any[c.twist, c.twist_vel, c.twist_moment])
+    return vars
 end
 
 function _particle_aero_connectors(np::Int)
@@ -59,9 +64,7 @@ function _particle_aero_connectors(np::Int)
     return (; point_pos, point_vel, point_force)
 end
 
-_particle_unknowns(c) =
-    [_flatten_vars(c.point_pos); _flatten_vars(c.point_vel);
-     _flatten_vars(c.point_force)]
+_particle_unknowns(c) = Any[c.point_pos, c.point_vel, c.point_force]
 
 function _wing_points(sys_struct, wing)
     return [p for p in sys_struct.points
@@ -78,7 +81,7 @@ function default_aero_none(sys_struct, wing_idx; name)
     if wing.dynamics_type == PARTICLE_DYNAMICS
         np = length(_wing_points(sys_struct, wing))
         c = _particle_aero_connectors(np)
-        eqs = [collect(c.point_force) .~ 0]
+        eqs = vec(collect(c.point_force)) .~ 0
         return System(eqs, t, _particle_unknowns(c), [psys]; name)
     end
 
@@ -188,8 +191,9 @@ function default_aero_linearized(sys_struct, wing_idx; name)
             (eqs = [eqs; c.twist_moment[gi] ~ qA * c_ref * coeff(6 + gi)])
     end
 
-    unknowns = [_rigid_unknowns(c); collect(aero_input)]
-    return System(eqs, t, unknowns, [psys]; name)
+    vars = _rigid_unknowns(c)
+    push!(vars, aero_input)
+    return System(eqs, t, vars, [psys]; name)
 end
 
 # ==================== PlateAero (not via component path) ==================== #
@@ -199,12 +203,6 @@ default_aero_plate(sys_struct, wing_idx; name) = error(
 
 # ==================== validation ==================== #
 
-"""
-    validate_aero_component(subsys, wing)
-
-Check that `subsys` (built by `wing.aero_model`) exposes the
-connector contract for the wing's `dynamics_type`.
-"""
 function validate_aero_component(subsys, wing)
     if wing.dynamics_type == RIGID_DYNAMICS
         required = Symbol[:va, :rho, :R_b_w, :omega, :force, :moment]

--- a/src/generate_system/create_sys.jl
+++ b/src/generate_system/create_sys.jl
@@ -227,21 +227,14 @@ function create_sys!(s::SymbolicAWEModel, system::SystemStructure;
 
     # ==================== END INLINED FORCE_EQS! CONTENT ==================== #
 
-    # Build aerodynamic equations (dispatches on aero_mode at runtime)
-    if has_particle_dynamics_wings
-        eqs, guesses = vsm_eqs!(
-            s, eqs, guesses, psys;
-            aero_force_b, aero_moment_b, group_aero_moment,
-            twist_angle, va_wing_b, wing_pos, ω_b,
-            aero_force_point_b=aero_force_point_b
-        )
-    else
-        eqs, guesses = vsm_eqs!(
-            s, eqs, guesses, psys;
-            aero_force_b, aero_moment_b, group_aero_moment,
-            twist_angle, va_wing_b, wing_pos, ω_b
-        )
-    end
+    # Build aerodynamic equations: each non-plate wing's aero component
+    # is wired in winch-style and returned as a subsystem.
+    eqs, guesses, aero_subsystems = vsm_eqs!(
+        s, eqs, guesses, psys;
+        aero_force_b, aero_moment_b, group_aero_moment,
+        twist_angle, twist_ω, va_wing_b, wing_pos, ω_b, R_b_to_w,
+        pos, vel, aero_force_point_b
+    )
 
     # Build plate aerodynamic equations for PlateWings
     for wing in wings
@@ -292,11 +285,12 @@ function create_sys!(s::SymbolicAWEModel, system::SystemStructure;
         end
     end
 
+    all_subsystems = [winch_subsystems; aero_subsystems]
     time = @elapsed begin
-        if isempty(winch_subsystems)
+        if isempty(all_subsystems)
             @named sys = System(eqs, t)
         else
-            @named sys = System(eqs, t; systems = winch_subsystems)
+            @named sys = System(eqs, t; systems = all_subsystems)
         end
     end
     prn && println("\tCreated System in $time seconds.")

--- a/src/generate_system/generate_system.jl
+++ b/src/generate_system/generate_system.jl
@@ -7,6 +7,7 @@
 # Utilities and accessors first (no dependencies)
 include("helpers.jl")
 include("accessors.jl")
+include("aero_components.jl")
 
 # Component equations (can be in any order - no inter-dependencies)
 include("point_eqs.jl")

--- a/src/generate_system/plate_eqs.jl
+++ b/src/generate_system/plate_eqs.jl
@@ -51,35 +51,35 @@ function plate_eqs!(s, eqs, psys, wing;
         plate_force_w(t)[1:3, 1:n_surf]
     end
 
-    for (si, surf) in enumerate(surfaces)
+    for (section_idx, surf) in enumerate(surfaces)
         pidx = surf.point_idx
 
         # Twist from surface
         eqs = [
             eqs
-            plate_twist[si] ~
-                get_surface_twist(psys, wing.idx, si)
+            plate_twist[section_idx] ~
+                get_surface_twist(psys, wing.idx, section_idx)
         ]
 
         # Get surface axes in body frame
         x_b = collect(
-            get_surface_x_airf(psys, wing.idx, si))
+            get_surface_x_airf(psys, wing.idx, section_idx))
         y_b = collect(
-            get_surface_y_airf(psys, wing.idx, si))
+            get_surface_y_airf(psys, wing.idx, section_idx))
         # z_b = x_b × y_b (normal)
 
         # Rotate x and z around y by twist (Rodrigues)
-        ct = cos(plate_twist[si])
-        st = sin(plate_twist[si])
-        x_twisted = ct * x_b + st * (y_b × x_b)
+        cos_twist = cos(plate_twist[section_idx])
+        sin_twist = sin(plate_twist[section_idx])
+        x_twisted = cos_twist * x_b + sin_twist * (y_b × x_b)
         z_twisted = x_twisted × y_b
 
         # Transform to world frame
         eqs = [
             eqs
-            plate_x_w[:, si] ~ Rbw * x_twisted
-            plate_y_w[:, si] ~ Rbw * y_b
-            plate_z_w[:, si] ~ Rbw * z_twisted
+            plate_x_w[:, section_idx] ~ Rbw * x_twisted
+            plate_y_w[:, section_idx] ~ Rbw * y_b
+            plate_z_w[:, section_idx] ~ Rbw * z_twisted
         ]
 
         # Apparent wind at surface point
@@ -89,100 +89,100 @@ function plate_eqs!(s, eqs, psys, wing;
             pos[3, pidx], psys) * wind_vec_gnd
         eqs = [
             eqs
-            plate_va_w[:, si] ~
+            plate_va_w[:, section_idx] ~
                 wind_at_h - vel[:, pidx]
         ]
 
         # AoA from wind projection (VSM convention)
-        va = collect(plate_va_w[:, si])
-        xw = collect(plate_x_w[:, si])
-        zw = collect(plate_z_w[:, si])
+        apparent_wind = collect(plate_va_w[:, section_idx])
+        x_axis_w = collect(plate_x_w[:, section_idx])
+        z_axis_w = collect(plate_z_w[:, section_idx])
         eqs = [
             eqs
-            plate_v_tan[si] ~ va ⋅ xw
-            plate_v_norm[si] ~ va ⋅ zw
-            plate_alpha[si] ~
-                rad2deg(atan(plate_v_norm[si],
-                             plate_v_tan[si]))
+            plate_v_tan[section_idx] ~ apparent_wind ⋅ x_axis_w
+            plate_v_norm[section_idx] ~ apparent_wind ⋅ z_axis_w
+            plate_alpha[section_idx] ~
+                rad2deg(atan(plate_v_norm[section_idx],
+                             plate_v_tan[section_idx]))
         ]
 
         # CL/CD lookup
         eqs = [
             eqs
-            plate_cl[si] ~ get_plate_cl(
-                psys, wing.idx, plate_alpha[si])
-            plate_cd[si] ~
+            plate_cl[section_idx] ~ get_plate_cl(
+                psys, wing.idx, plate_alpha[section_idx])
+            plate_cd[section_idx] ~
                 get_plate_drag_corr(psys, wing.idx) *
                 get_plate_cd(
-                    psys, wing.idx, plate_alpha[si])
+                    psys, wing.idx, plate_alpha[section_idx])
         ]
 
         # Dynamic pressure: in-plane for lift, full for drag
-        va = collect(plate_va_w[:, si])
+        apparent_wind = collect(plate_va_w[:, section_idx])
         eqs = [
             eqs
-            plate_q[si] ~ 0.5 *
+            plate_q[section_idx] ~ 0.5 *
                 calc_rho(s.am, height[pidx]) *
-                (plate_v_tan[si]^2 + plate_v_norm[si]^2)
-            plate_q_drag[si] ~ 0.5 *
+                (plate_v_tan[section_idx]^2 + plate_v_norm[section_idx]^2)
+            plate_q_drag[section_idx] ~ 0.5 *
                 calc_rho(s.am, height[pidx]) *
-                (va ⋅ va)
+                (apparent_wind ⋅ apparent_wind)
         ]
 
         # Lift and drag directions (VSM convention):
         # Effective flow in airfoil plane, then lift
         # perpendicular and drag along flow.
-        alpha_rad = atan(plate_v_norm[si], plate_v_tan[si])
-        va_airf_dir = cos(alpha_rad) * xw +
-                      sin(alpha_rad) * zw
-        yw = collect(plate_y_w[:, si])
-        lift_dir = smooth_normalize(va_airf_dir × yw)
-        drag_dir = smooth_normalize(yw × lift_dir)
+        alpha_rad = atan(plate_v_norm[section_idx], plate_v_tan[section_idx])
+        va_airf_dir = cos(alpha_rad) * x_axis_w +
+                      sin(alpha_rad) * z_axis_w
+        y_axis_w = collect(plate_y_w[:, section_idx])
+        lift_dir = smooth_normalize(va_airf_dir × y_axis_w)
+        drag_dir = smooth_normalize(y_axis_w × lift_dir)
 
-        area = get_surface_area(psys, wing.idx, si)
+        area = get_surface_area(psys, wing.idx, section_idx)
         eqs = [
             eqs
-            plate_lift[:, si] ~
-                plate_q[si] * area *
-                plate_cl[si] * lift_dir
-            plate_drag[:, si] ~
-                plate_q_drag[si] * area *
-                plate_cd[si] * drag_dir
-            plate_force_w[:, si] ~
-                plate_lift[:, si] + plate_drag[:, si]
+            plate_lift[:, section_idx] ~
+                plate_q[section_idx] * area *
+                plate_cl[section_idx] * lift_dir
+            plate_drag[:, section_idx] ~
+                plate_q_drag[section_idx] * area *
+                plate_cd[section_idx] * drag_dir
+            plate_force_w[:, section_idx] ~
+                plate_lift[:, section_idx] + plate_drag[:, section_idx]
         ]
     end
 
     # Apply forces depending on wing type
     if wing.dynamics_type == PARTICLE_DYNAMICS
         # Per-point forces in body frame
-        afpb = aero_force_point_b::AbstractArray
-        for (si, surf) in enumerate(surfaces)
+        aero_force_point = aero_force_point_b::AbstractArray
+        for (section_idx, surf) in enumerate(surfaces)
             pidx = surf.point_idx
             eqs = [
                 eqs
-                afpb[:, pidx] ~
-                    Rbw' * plate_force_w[:, si]
+                aero_force_point[:, pidx] ~
+                    Rbw' * plate_force_w[:, section_idx]
             ]
         end
         # Wing-level: sum of all surface forces (body frame)
         eqs = [
             eqs
             aero_force_b[:, wing.idx] ~
-                sum([Rbw' * plate_force_w[:, si]
-                     for si in 1:n_surf])
+                sum([Rbw' * plate_force_w[:, section_idx]
+                     for section_idx in 1:n_surf])
             aero_moment_b[:, wing.idx] ~ zeros(3)
         ]
     elseif wing.dynamics_type == RIGID_DYNAMICS
         # Sum forces and moments about COM
         force_sum = sum([
-            Rbw' * plate_force_w[:, si]
-            for si in 1:n_surf])
+            Rbw' * plate_force_w[:, section_idx]
+            for section_idx in 1:n_surf])
         moment_sum = sum([
-            Rbw' * ((pos[:, surfaces[si].point_idx] -
+            Rbw' * ((pos[:, surfaces[section_idx].point_idx] -
                      com_w[:, wing.idx]) ×
-                    plate_force_w[:, si])
-            for si in 1:n_surf])
+                    plate_force_w[:, section_idx])
+            for section_idx in 1:n_surf])
         eqs = [
             eqs
             aero_force_b[:, wing.idx] ~ force_sum

--- a/src/generate_system/vsm_eqs.jl
+++ b/src/generate_system/vsm_eqs.jl
@@ -1,297 +1,98 @@
 # Copyright (c) 2025 Bart van de Lint
 # SPDX-License-Identifier: LGPL-3.0-only
 
-# VSM aerodynamics equation generation
+# Aero coupling wiring (winch-style).
 #
-# Aero mode is a build-time decision (part of model SHA hash).
-# Each mode generates only the equations it needs:
-#   AERO_NONE:       zeros (no VSM calls)
-#   AERO_DIRECT:     reads stored forces via registered functions
-#   AERO_LINEARIZED: wind-axis coefficient linearization
-#                    with q∞·A·(CL·lift - CD·drag + CS·side)
-#
-# PARTICLE_DYNAMICS wings use per-point forces via get_point_aero_force.
+# Each non-plate wing's aerodynamics is a swappable subsystem built by
+# `wing.aero_model` (see aero_components.jl). This layer instantiates
+# the component, validates its connector contract, drives the body-frame
+# inputs, and reads the outputs back into the wing's aero variables.
+# All built-in modes (AERO_NONE / AERO_DIRECT / AERO_LINEARIZED) and any
+# AERO_CUSTOM model go through the same wiring.
 
 """
     vsm_eqs!(s, eqs, guesses, psys; kwargs...)
+        -> (eqs, guesses, aero_subsystems)
 
-Generate aerodynamic equations for all wings.
-
-Aero mode is resolved at build time — each wing's `aero_mode`
-determines which equations are generated:
-- `AERO_LINEARIZED`: wind-axis coefficient equations with
-  Jacobian-based linearization around the operating point
-- `AERO_DIRECT`: registered functions returning stored forces
-- `AERO_NONE`: zeros
-
-For PARTICLE_DYNAMICS wings, per-point forces come from
-`get_point_aero_force` (which also respects `AERO_NONE`).
+Instantiate and wire each wing's aero component. Returns the list of
+component subsystems to attach to the parent `System`.
 """
 function vsm_eqs!(
     s, eqs, guesses, psys;
     aero_force_b, aero_moment_b, group_aero_moment,
-    twist_angle, va_wing_b, wing_pos, ω_b,
-    aero_force_point_b=nothing
+    twist_angle, twist_ω, va_wing_b, wing_pos, ω_b, R_b_to_w,
+    pos, vel, aero_force_point_b=nothing
 )
     (; groups, wings, points) = s.sys_struct
-    length(wings) == 0 && return eqs, guesses
-
-    # Predeclare symbolic arrays
-    aero_input = nothing
-    aero_input_delta = nothing
-    aero_input_prev = nothing
-    aero_jac_sym = nothing
-    aero_coeffs_prev = nothing
-    q_inf = nothing
-
-    has_linearized = any(
-        w isa VSMWing &&
-        w.dynamics_type == RIGID_DYNAMICS &&
-        w.aero_mode == AERO_LINEARIZED
-        for w in wings)
-
-    # Declare symbolic variables for AERO_LINEARIZED
-    if has_linearized
-        first_lin_wing = first(
-            w for w in wings if w isa VSMWing &&
-            w.dynamics_type == RIGID_DYNAMICS &&
-            w.aero_mode == AERO_LINEARIZED)
-        ny = length(first_lin_wing.aero_y)
-        nx_values = [
-            length(w.aero_x)
-            for w in wings
-            if w isa VSMWing &&
-               w.dynamics_type == RIGID_DYNAMICS &&
-               w.aero_mode == AERO_LINEARIZED]
-        nx = maximum(nx_values)
-
-        @variables begin
-            aero_input(t)[1:ny, eachindex(wings)]
-            aero_input_delta(t)[
-                1:ny, eachindex(wings)]
-            aero_input_prev(t)[
-                1:ny, eachindex(wings)]
-            aero_jac_sym(t)[
-                1:nx, 1:ny, eachindex(wings)]
-            aero_coeffs_prev(t)[
-                1:nx, eachindex(wings)]
-            q_inf(t)[eachindex(wings)]
-        end
-    end
+    aero_subsystems = Any[]
+    length(wings) == 0 && return eqs, guesses, aero_subsystems
 
     for wing in wings
-        if wing isa PlateWing
-            # PlateWing equations are generated in plate_eqs!()
-            continue
+        wing isa PlateWing && continue   # handled by plate_eqs!
 
-        elseif wing isa VSMWing && wing.dynamics_type == PARTICLE_DYNAMICS
-            # ========== PARTICLE_DYNAMICS WING ==========
+        w = wing.idx
+        subsys = wing.aero_model(s.sys_struct, w;
+                                 name = Symbol("aero_$(w)"))
+        validate_aero_component(subsys, wing)
+        push!(aero_subsystems, subsys)
+
+        if wing.dynamics_type == PARTICLE_DYNAMICS
+            wing_points = [p for p in points
+                           if p.type == WING && p.wing_idx == w]
+            Rbw = R_b_to_w[:, :, w]
             afpb = aero_force_point_b::AbstractArray
-            wing_points = [
-                p for p in points
-                if p.type == WING &&
-                    p.wing_idx == wing.idx
-            ]
-
-            if wing.aero_mode == AERO_NONE
-                for point in wing_points
-                    eqs = [
-                        eqs
-                        afpb[:, point.idx] ~ zeros(3)
-                    ]
-                end
-            else
-                # AERO_DIRECT: per-point forces
-                for point in wing_points
-                    eqs = [
-                        eqs
-                        afpb[:, point.idx] ~ [
-                            get_point_aero_force(
-                                psys, point.idx, i)
-                            for i in 1:3
-                        ]
-                    ]
-                end
+            for (k, point) in enumerate(wing_points)
+                eqs = [eqs
+                       collect(subsys.point_pos[:, k]) .~
+                           collect(Rbw' * collect(pos[:, point.idx] -
+                                                  wing_pos[:, w]))
+                       collect(subsys.point_vel[:, k]) .~
+                           collect(Rbw' * collect(vel[:, point.idx]))
+                       collect(afpb[:, point.idx]) .~
+                           collect(subsys.point_force[:, k])]
             end
+            eqs = [eqs
+                   collect(aero_force_b[:, w]) .~
+                       sum(collect(afpb[:, p.idx])
+                           for p in wing_points)
+                   collect(aero_moment_b[:, w]) .~ 0]
+            continue
+        end
 
-            eqs = [
-                eqs
-                aero_force_b[:, wing.idx] ~
-                    sum([afpb[:, p.idx]
-                         for p in wing_points])
-                aero_moment_b[:, wing.idx] ~ zeros(3)
-            ]
+        # RIGID_DYNAMICS
+        ng = length(wing.group_idxs)
+        rho = calc_rho(s.am, wing_pos[3, w])
+        eqs = [eqs
+               collect(subsys.va) .~ collect(va_wing_b[:, w])
+               subsys.rho ~ rho
+               vec(collect(subsys.R_b_w)) .~ vec(R_b_to_w[:, :, w])
+               collect(subsys.omega) .~ collect(ω_b[:, w])]
+        if ng > 0
+            eqs = [eqs
+                   collect(subsys.twist) .~
+                       [twist_angle[groups[gidx].idx]
+                        for gidx in wing.group_idxs]
+                   collect(subsys.twist_vel) .~
+                       [twist_ω[groups[gidx].idx]
+                        for gidx in wing.group_idxs]]
+        end
 
-        elseif wing.aero_mode == AERO_NONE
-            # ========== RIGID_DYNAMICS + AERO_NONE =====
-            eqs = [
-                eqs
-                aero_force_b[:, wing.idx] ~ zeros(3)
-                aero_moment_b[:, wing.idx] ~ zeros(3)
-            ]
-            for gidx in wing.group_idxs
-                group = groups[gidx]
-                isempty(
-                    group.unrefined_section_idxs
-                ) && continue
-                eqs = [
-                    eqs
-                    group_aero_moment[group.idx] ~ 0
-                ]
-            end
+        eqs = [eqs
+               collect(aero_force_b[:, w]) .~ collect(subsys.force)
+               collect(aero_moment_b[:, w]) .~ collect(subsys.moment)]
+        for (gi, gidx) in enumerate(wing.group_idxs)
+            isempty(groups[gidx].unrefined_section_idxs) && continue
+            eqs = [eqs
+                   group_aero_moment[groups[gidx].idx] ~
+                       subsys.twist_moment[gi]]
+        end
 
-        elseif wing.aero_mode == AERO_DIRECT
-            # ========== RIGID_DYNAMICS + AERO_DIRECT ===
-            eqs = [
-                eqs
-                aero_force_b[:, wing.idx] ~ [
-                    get_aero_force_override(
-                        psys, wing.idx, c)
-                    for c in 1:3]
-                aero_moment_b[:, wing.idx] ~ [
-                    get_aero_moment_override(
-                        psys, wing.idx, c)
-                    for c in 1:3]
-            ]
-            for gidx in wing.group_idxs
-                group = groups[gidx]
-                isempty(
-                    group.unrefined_section_idxs
-                ) && continue
-                eqs = [
-                    eqs
-                    group_aero_moment[group.idx] ~
-                        get_group_moment_override(
-                            psys, wing.idx,
-                            Int64(gidx))
-                ]
-            end
-
-        else
-            # ========== RIGID_DYNAMICS + AERO_LINEARIZED
-            # Wind-axis coefficient linearization
-            wing isa VSMWing || error(
-                "AERO_LINEARIZED wing $(wing.idx)" *
-                " is not a VSMWing")
-
-            area = wing.vsm_aero.projected_area
-            c_ref = wing.vsm_aero.c_ref
-            ny_w = length(wing.aero_y)
-            nx_w = length(wing.aero_x)
-            w = wing.idx
-
-            # ── Load stored operating point ──────
-            prev_input_eqs = [
-                aero_input_prev[iy, w] ~
-                    get_aero_y(psys, w, iy)
-                for iy in 1:ny_w]
-
-            prev_coeff_eqs = [
-                aero_coeffs_prev[ix, w] ~
-                    get_aero_x(psys, w, ix)
-                for ix in 1:nx_w]
-
-            jac_eqs = [
-                aero_jac_sym[ix, iy, w] ~
-                    get_aero_jac(psys, w, ix, iy)
-                for ix in 1:nx_w for iy in 1:ny_w]
-
-            # ── Current input state (symbolic) ───
-            # collect() so smooth_norm's mapreduce scalarises
-            va = collect(va_wing_b[:, w])
-            drag_dir = collect(va ./ smooth_norm(va))
-            alpha_sym = atan(drag_dir[3], drag_dir[1])
-            beta_sym = atan(drag_dir[2],
-                smooth_norm((drag_dir[1], drag_dir[3])))
-
-            twist_inputs = [
-                twist_angle[groups[gidx].idx]
-                for gidx in wing.group_idxs]
-
-            eqs = [
-                eqs
-                q_inf[w] ~
-                    0.5 *
-                    calc_rho(s.am, wing_pos[3, w]) *
-                    (va ⋅ va)
-
-                prev_input_eqs
-                prev_coeff_eqs
-                jac_eqs
-
-                aero_input[:, w] ~ [
-                    alpha_sym
-                    beta_sym
-                    ω_b[1, w]
-                    ω_b[2, w]
-                    ω_b[3, w]
-                    twist_inputs
-                ]
-
-                aero_input_delta[:, w] ~
-                    aero_input[:, w] -
-                    aero_input_prev[:, w]
-            ]
-
-            # ── Coefficient reconstruction ───────
-            # coeff(ix) = x0[ix] + Σ J[ix,iy]*Δ[iy]
-            delta = aero_input_delta[:, w]
-            J = aero_jac_sym[:, :, w]
-            x0 = aero_coeffs_prev[:, w]
-
-            coeff(ix) = x0[ix] + sum(
-                J[ix, iy] * delta[iy] for iy in 1:ny_w)
-
-            CL = coeff(1)
-            CD = coeff(2)
-            CS = coeff(3)
-            qA = q_inf[w] * area
-
-            # ── Wind-axis basis (matches VSM) ────
-            # drag = va / |va|
-            # lift = normalize(drag × span)
-            # side = lift × drag   (orthonormal triad)
-            crossed = collect(drag_dir × [0.0, 1.0, 0.0])
-            lift_dir = collect(
-                crossed ./ smooth_norm(crossed))
-            side_dir = collect(lift_dir × drag_dir)
-
-            drag_frac = get_drag_frac(psys, w)
-            force_eq = collect(qA * (
-                CL * lift_dir +
-                CD * drag_frac * drag_dir +
-                CS * side_dir))
-
-            moment_eq = [
-                qA * c_ref * coeff(3 + i) for i in 1:3]
-
-            group_moment_eqs = [
-                group_aero_moment[groups[gidx].idx] ~
-                    qA * c_ref * coeff(6 + gi)
-                for (gi, gidx) in
-                    enumerate(wing.group_idxs)
-                if !isempty(
-                    groups[gidx].unrefined_section_idxs)]
-
-            eqs = [
-                eqs
-                group_moment_eqs
-
-                aero_force_b[:, w] ~ force_eq
-                aero_moment_b[:, w] ~ moment_eq
-            ]
-
-            if s.set.quasi_static
-                wing_guesses = [
-                    aero_input[iy, w] =>
-                        get_aero_y(psys, w, iy)
-                    for iy in 1:ny_w]
-                guesses = [
-                    guesses
-                    wing_guesses
-                ]
-            end
+        if s.set.quasi_static && hasproperty(subsys, :aero_input)
+            ny = length(wing.aero_y)
+            guesses = [guesses
+                       [subsys.aero_input[iy] => get_aero_y(psys, w, iy)
+                        for iy in 1:ny]]
         end
     end
-    return eqs, guesses
+    return eqs, guesses, aero_subsystems
 end

--- a/src/generate_system/vsm_eqs.jl
+++ b/src/generate_system/vsm_eqs.jl
@@ -30,44 +30,44 @@ function vsm_eqs!(
     for wing in wings
         wing isa PlateWing && continue   # handled by plate_eqs!
 
-        w = wing.idx
-        subsys = wing.aero_model(s.sys_struct, w;
-                                 name = Symbol("aero_$(w)"))
+        wing_idx = wing.idx
+        subsys = wing.aero_model(s.sys_struct, wing_idx;
+                                 name = Symbol("aero_$(wing_idx)"))
         validate_aero_component(subsys, wing)
         push!(aero_subsystems, subsys)
 
         if wing.dynamics_type == PARTICLE_DYNAMICS
-            wing_points = [p for p in points
-                           if p.type == WING && p.wing_idx == w]
-            Rbw = R_b_to_w[:, :, w]
-            afpb = aero_force_point_b::AbstractArray
+            wing_points = [point for point in points
+                           if point.type == WING && point.wing_idx == wing_idx]
+            Rbw = R_b_to_w[:, :, wing_idx]
+            aero_force_point = aero_force_point_b::AbstractArray
             for (k, point) in enumerate(wing_points)
                 eqs = [eqs
                        collect(subsys.point_pos[:, k]) .~
                            collect(Rbw' * collect(pos[:, point.idx] -
-                                                  wing_pos[:, w]))
+                                                  wing_pos[:, wing_idx]))
                        collect(subsys.point_vel[:, k]) .~
                            collect(Rbw' * collect(vel[:, point.idx]))
-                       collect(afpb[:, point.idx]) .~
+                       collect(aero_force_point[:, point.idx]) .~
                            collect(subsys.point_force[:, k])]
             end
             eqs = [eqs
-                   collect(aero_force_b[:, w]) .~
-                       sum(collect(afpb[:, p.idx])
-                           for p in wing_points)
-                   collect(aero_moment_b[:, w]) .~ 0]
+                   collect(aero_force_b[:, wing_idx]) .~
+                       sum(collect(aero_force_point[:, point.idx])
+                           for point in wing_points)
+                   collect(aero_moment_b[:, wing_idx]) .~ 0]
             continue
         end
 
         # RIGID_DYNAMICS
-        ng = length(wing.group_idxs)
-        rho = calc_rho(s.am, wing_pos[3, w])
+        num_groups = length(wing.group_idxs)
+        rho = calc_rho(s.am, wing_pos[3, wing_idx])
         eqs = [eqs
-               collect(subsys.va) .~ collect(va_wing_b[:, w])
+               collect(subsys.va) .~ collect(va_wing_b[:, wing_idx])
                subsys.rho ~ rho
-               vec(collect(subsys.R_b_w)) .~ vec(R_b_to_w[:, :, w])
-               collect(subsys.omega) .~ collect(ω_b[:, w])]
-        if ng > 0
+               vec(collect(subsys.R_b_w)) .~ vec(R_b_to_w[:, :, wing_idx])
+               collect(subsys.omega) .~ collect(ω_b[:, wing_idx])]
+        if num_groups > 0
             eqs = [eqs
                    collect(subsys.twist) .~
                        [twist_angle[groups[gidx].idx]
@@ -78,20 +78,21 @@ function vsm_eqs!(
         end
 
         eqs = [eqs
-               collect(aero_force_b[:, w]) .~ collect(subsys.force)
-               collect(aero_moment_b[:, w]) .~ collect(subsys.moment)]
-        for (gi, gidx) in enumerate(wing.group_idxs)
+               collect(aero_force_b[:, wing_idx]) .~ collect(subsys.force)
+               collect(aero_moment_b[:, wing_idx]) .~ collect(subsys.moment)]
+        for (group_pos, gidx) in enumerate(wing.group_idxs)
             isempty(groups[gidx].unrefined_section_idxs) && continue
             eqs = [eqs
                    group_aero_moment[groups[gidx].idx] ~
-                       subsys.twist_moment[gi]]
+                       subsys.twist_moment[group_pos]]
         end
 
         if s.set.quasi_static && hasproperty(subsys, :aero_input)
-            ny = length(wing.aero_y)
+            num_aero_inputs = length(wing.aero_y)
             guesses = [guesses
-                       [subsys.aero_input[iy] => get_aero_y(psys, w, iy)
-                        for iy in 1:ny]]
+                       [subsys.aero_input[input_idx] =>
+                            get_aero_y(psys, wing_idx, input_idx)
+                        for input_idx in 1:num_aero_inputs]]
         end
     end
     return eqs, guesses, aero_subsystems

--- a/src/generate_system/winch_eqs.jl
+++ b/src/generate_system/winch_eqs.jl
@@ -113,10 +113,10 @@ function validate_winch_component(subsys, winch)
     end
     for eq in ModelingToolkit.equations(subsys)
         lhs = ModelingToolkit.Symbolics.unwrap(eq.lhs)
-        nm = _differential_inner_name(lhs)
-        if nm === :vel || nm === :len
+        var_name = _differential_inner_name(lhs)
+        if var_name === :vel || var_name === :len
             error("Winch $(winch.name): component must not define " *
-                  "`D($nm) ~ …`; that derivative is owned by the outer " *
+                  "`D($var_name) ~ …`; that derivative is owned by the outer " *
                   "system.")
         end
     end
@@ -126,8 +126,8 @@ end
 function _differential_inner_name(expr)
     try
         ModelingToolkit.iscall(expr) || return nothing
-        op = ModelingToolkit.operation(expr)
-        op isa ModelingToolkit.Differential || return nothing
+        mtk_operation = ModelingToolkit.operation(expr)
+        mtk_operation isa ModelingToolkit.Differential || return nothing
         arg = ModelingToolkit.arguments(expr)[1]
         ModelingToolkit.iscall(arg) || return nothing
         inner = ModelingToolkit.operation(arg)
@@ -154,7 +154,7 @@ For each winch:
 3. Validate the connector contract with
    [`validate_winch_component`](@ref).
 4. Bind connectors to the parent variables (including
-   `subsys.len ~ mean(tether_len[ti] for ti in winch.tether_idxs)`)
+   `subsys.len ~ mean(tether_len[tether_idx] for tether_idx in winch.tether_idxs)`)
    and integrate `D(winch_vel) = ifelse(brake > 0.5, 0, winch_acc)`.
    When `winch.speed_controlled` is true, `winch_acc` is forced to 0
    (ignoring `subsys.acc`) so velocity is prescribed via `winch.vel`.
@@ -170,22 +170,22 @@ function winch_eqs!(eqs, defaults, winches, tethers, segments, points,
                     winch_friction)
     tether_winch = Dict{Int, Int}()
     for winch in winches
-        for ti in winch.tether_idxs
-            haskey(tether_winch, ti) && error(
-                "Tether $ti is connected to winch " *
-                "$(tether_winch[ti]) and winch $(winch.idx). " *
+        for tether_idx in winch.tether_idxs
+            haskey(tether_winch, tether_idx) && error(
+                "Tether $tether_idx is connected to winch " *
+                "$(tether_winch[tether_idx]) and winch $(winch.idx). " *
                 "Each tether can have at most one winch.")
-            tether_winch[ti] = winch.idx
+            tether_winch[tether_idx] = winch.idx
         end
     end
 
     for tether in tethers
         if haskey(tether_winch, tether.idx)
-            wi = tether_winch[tether.idx]
+            winch_idx = tether_winch[tether.idx]
             eqs = [eqs
                    D(tether_len[tether.idx]) ~
-                       ifelse(get_brake(psys, wi) > 0.5,
-                              0, winch_vel[wi])]
+                       ifelse(get_brake(psys, winch_idx) > 0.5,
+                              0, winch_vel[winch_idx])]
         else
             eqs = [eqs; D(tether_len[tether.idx]) ~ 0]
         end
@@ -199,21 +199,21 @@ function winch_eqs!(eqs, defaults, winches, tethers, segments, points,
         isempty(winch.tether_idxs) &&
             error("Winch $(winch.name): no connected tethers; " *
                   "at least one is required.")
-        wp = winch.winch_point_idx
-        (wp > length(points)) &&
-            error("Winch $(winch.name): point $wp does not exist.")
+        winch_point_idx = winch.winch_point_idx
+        (winch_point_idx > length(points)) &&
+            error("Winch $(winch.name): point $winch_point_idx does not exist.")
 
         winch_seg_idxs = Set{Int}()
-        for ti in winch.tether_idxs
-            union!(winch_seg_idxs, tethers[ti].segment_idxs)
+        for tether_idx in winch.tether_idxs
+            union!(winch_seg_idxs, tethers[tether_idx].segment_idxs)
         end
         force_vec = zeros(Num, 3)
-        for seg in segments
-            seg.idx in winch_seg_idxs || continue
-            if seg.point_idxs[1] == wp
-                force_vec .+= spring_force_vec[:, seg.idx]
-            elseif seg.point_idxs[2] == wp
-                force_vec .-= spring_force_vec[:, seg.idx]
+        for segment in segments
+            segment.idx in winch_seg_idxs || continue
+            if segment.point_idxs[1] == winch_point_idx
+                force_vec .+= spring_force_vec[:, segment.idx]
+            elseif segment.point_idxs[2] == winch_point_idx
+                force_vec .-= spring_force_vec[:, segment.idx]
             end
         end
 
@@ -229,7 +229,7 @@ function winch_eqs!(eqs, defaults, winches, tethers, segments, points,
                    smooth_norm(winch_force_vec[:, winch.idx])
                subsys.vel       ~ winch_vel[winch.idx]
                subsys.len       ~
-                   sum(tether_len[ti] for ti in winch.tether_idxs) /
+                   sum(tether_len[tether_idx] for tether_idx in winch.tether_idxs) /
                    length(winch.tether_idxs)
                subsys.force     ~ winch_force[winch.idx]
                subsys.set_value ~ set_values[winch.idx]

--- a/src/generate_system/winch_eqs.jl
+++ b/src/generate_system/winch_eqs.jl
@@ -155,7 +155,9 @@ For each winch:
    [`validate_winch_component`](@ref).
 4. Bind connectors to the parent variables (including
    `subsys.len ~ mean(tether_len[ti] for ti in winch.tether_idxs)`)
-   and integrate `D(winch_vel) = ifelse(brake > 0.5, 0, subsys.acc)`.
+   and integrate `D(winch_vel) = ifelse(brake > 0.5, 0, winch_acc)`.
+   When `winch.speed_controlled` is true, `winch_acc` is forced to 0
+   (ignoring `subsys.acc`) so velocity is prescribed via `winch.vel`.
 
 For each tether:
 - With winch:    `D(tether_len) = ifelse(brake > 0.5, 0, winch_vel)`.
@@ -232,7 +234,9 @@ function winch_eqs!(eqs, defaults, winches, tethers, segments, points,
                subsys.force     ~ winch_force[winch.idx]
                subsys.set_value ~ set_values[winch.idx]
                subsys.brake     ~ brake_p
-               winch_acc[winch.idx]      ~ subsys.acc
+               winch_acc[winch.idx]      ~
+                   ifelse(get_speed_controlled(psys, winch.idx) == true,
+                          0.0, subsys.acc)
                winch_friction[winch.idx] ~ subsys.friction
                D(winch_vel[winch.idx]) ~
                    ifelse(brake_p > 0.5, 0, winch_acc[winch.idx])]

--- a/src/linearize.jl
+++ b/src/linearize.jl
@@ -198,10 +198,11 @@ function _safe_vsm_solve!(solver, body_aero,
         VortexStepMethod.solve!(solver, body_aero, gamma_init;
             moment_frac, log=false)
     end
-    cf = solver.sol.force_coeffs
-    cm = solver.sol.moment_coeffs
+    force_coeffs = solver.sol.force_coeffs
+    moment_coeffs = solver.sol.moment_coeffs
     if !solver.lr.converged ||
-            any(!_finite_full, cf) || any(!_finite_full, cm)
+            any(!_finite_full, force_coeffs) ||
+            any(!_finite_full, moment_coeffs)
         if !isnothing(solver.sol.gamma_distribution)
             fill!(solver.sol.gamma_distribution, 0)
         end
@@ -221,14 +222,14 @@ function _vsm_aero_coeffs(wing, y::AbstractVector{T},
         solver_c = wing.vsm_solver
         wing_c = wing.vsm_wing
     else
-        sh = shadow_ref[]
-        if sh === nothing || eltype(sh[1]._va) !== T
+        shadow = shadow_ref[]
+        if shadow === nothing || eltype(shadow[1]._va) !== T
             shadow_ref[] = VortexStepMethod.make_dual_shadow(
                 wing.vsm_solver, wing.vsm_aero, T)
-            sh = shadow_ref[]
-            sh[2].use_gamma_prev = true
+            shadow = shadow_ref[]
+            shadow[2].use_gamma_prev = true
         end
-        body_aero_c, solver_c = sh
+        body_aero_c, solver_c = shadow
         wing_c = body_aero_c.wings[1]
     end
 
@@ -245,9 +246,9 @@ function _vsm_aero_coeffs(wing, y::AbstractVector{T},
 
     # Per-group → per-section twist
     theta = zeros(T, n_unrefined)
-    for (gi, gidx) in enumerate(group_idxs)
-        for ui in groups[gidx].unrefined_section_idxs
-            theta[ui] = y[5 + gi]
+    for (group_index, gidx) in enumerate(group_idxs)
+        for unrefined_index in groups[gidx].unrefined_section_idxs
+            theta[unrefined_index] = y[5 + group_index]
         end
     end
 
@@ -264,7 +265,7 @@ function _vsm_aero_coeffs(wing, y::AbstractVector{T},
     end
 
     sol = solver_c.sol
-    cf = sol.force_coeffs
+    force_coeffs = sol.force_coeffs
     cm_body = sol.moment_coeffs
     moment_coeff_unrefined = sol.moment_coeff_unrefined_dist
 
@@ -276,15 +277,17 @@ function _vsm_aero_coeffs(wing, y::AbstractVector{T},
     side_dir = cross(lift_dir, drag_dir)
 
     x = zeros(T, 6 + n_groups)
-    x[1] = dot(cf, lift_dir)
-    x[2] = dot(cf, drag_dir)
-    x[3] = dot(cf, side_dir)
+    x[1] = dot(force_coeffs, lift_dir)
+    x[2] = dot(force_coeffs, drag_dir)
+    x[3] = dot(force_coeffs, side_dir)
     x[4] = cm_body[1]
     x[5] = cm_body[2]
     x[6] = cm_body[3]
-    for (gi, gidx) in enumerate(group_idxs)
-        x[6 + gi] = sum(moment_coeff_unrefined[ui]
-            for ui in groups[gidx].unrefined_section_idxs;
+    for (group_index, gidx) in enumerate(group_idxs)
+        x[6 + group_index] = sum(
+            moment_coeff_unrefined[unrefined_index]
+            for unrefined_index in
+                groups[gidx].unrefined_section_idxs;
             init = zero(T))
     end
     return x
@@ -330,8 +333,8 @@ function _update_rigid_dynamics_wing!(wing, am, groups;
     y0[3] = omega_b[1]
     y0[4] = omega_b[2]
     y0[5] = omega_b[3]
-    for (gi, gidx) in enumerate(group_idxs)
-        y0[5 + gi] = groups[gidx].twist
+    for (group_index, gidx) in enumerate(group_idxs)
+        y0[5 + group_index] = groups[gidx].twist
     end
 
     shadow_ref = Ref{Any}(nothing)
@@ -340,8 +343,8 @@ function _update_rigid_dynamics_wing!(wing, am, groups;
         moment_frac, shadow_ref)
 
     wing.aero_x .= f_baseline(y0)
-    for (gi, gidx) in enumerate(group_idxs)
-        groups[gidx].aero_moment = wing.aero_x[6 + gi]
+    for (group_index, gidx) in enumerate(group_idxs)
+        groups[gidx].aero_moment = wing.aero_x[6 + group_index]
     end
 
     if wing.aero_mode == AERO_LINEARIZED

--- a/src/model_management.jl
+++ b/src/model_management.jl
@@ -1,6 +1,13 @@
 # Copyright (c) 2025 Bart van de Lint and Uwe Fechner
 # SPDX-License-Identifier: LGPL-3.0-only
 
+function make_psys_setter(sys)
+    psys_params = filter(p -> endswith(string(p), "psys"), parameters(sys))
+    setter = setp(sys, psys_params)
+    n = length(psys_params)
+    return (prob, ss) -> setter(prob, ntuple(_ -> ss, n))
+end
+
 """
     generate_prob_getters(sys_struct, sys)
 
@@ -16,13 +23,6 @@ of the compiled `ODESystem` (`sys`).
 # Returns
 - A `NamedTuple` containing various getter and setter functions for different parts of the system state.
 """
-function make_psys_setter(sys)
-    psys_params = filter(p -> endswith(string(p), "psys"), parameters(sys))
-    setter = setp(sys, psys_params)
-    n = length(psys_params)
-    return (prob, ss) -> setter(prob, ntuple(_ -> ss, n))
-end
-
 function generate_prob_getters(sys_struct, sys)
     c = collect
     (; wings, groups, pulleys, winches, tethers, segments) = sys_struct
@@ -297,6 +297,13 @@ function maybe_create_control_functions!(sam, outputs; create_control_func=false
     return false
 end
 
+"""
+    has_custom_component(sys_struct)
+
+Return `true` when the system has a non-default winch model or a wing using
+`AERO_CUSTOM`, in which case the compiled model cannot be reused from cache and
+must be rebuilt.
+"""
 function has_custom_component(sys_struct)
     any(w.model !== default_winch_component
         for w in sys_struct.winches) && return true

--- a/src/model_management.jl
+++ b/src/model_management.jl
@@ -49,7 +49,12 @@ function generate_prob_getters(sys_struct, sys)
             w.aero_mode === AERO_LINEARIZED
             for w in sys_struct.wings)
         if has_linearized
-            get_aero_input = getu(sys, sys.aero_input)
+            aero_inputs = [
+                getproperty(sys, Symbol("aero_$(w.idx)")).aero_input
+                for w in sys_struct.wings
+                if w.dynamics_type === RIGID_DYNAMICS &&
+                   w.aero_mode === AERO_LINEARIZED]
+            get_aero_input = getu(sys, c.(aero_inputs))
         else
             get_aero_input = nothing
         end
@@ -286,6 +291,22 @@ function maybe_create_control_functions!(sam, outputs; create_control_func=false
 end
 
 """
+    has_custom_component(sys_struct) -> Bool
+
+True if any winch or wing carries a user-supplied component builder
+whose equations are not captured by the model hash (a custom
+`winch.model`, or a wing with `aero_mode == AERO_CUSTOM`). Used by
+`init!` to default `remake=true` for such models.
+"""
+function has_custom_component(sys_struct)
+    any(w.model !== default_winch_component
+        for w in sys_struct.winches) && return true
+    any(w.aero_mode == AERO_CUSTOM
+        for w in sys_struct.wings) && return true
+    return false
+end
+
+"""
     init!(sam::SymbolicAWEModel; ...)
 
 Load or build the symbolic model, create the `ODEProblem` (and optionally the
@@ -296,7 +317,9 @@ return a freshly initialized `ODEIntegrator`.
 - `solver`, `adaptive`: ODE solver and time-stepping mode. `solver=nothing` picks
   a default from `sam.set.solver`.
 - `prn`: print progress messages.
-- `remake`: force a full rebuild, ignoring any cached compiled model.
+- `remake`: force a full rebuild, ignoring any cached compiled model. Defaults to
+  `nothing`, which rebuilds automatically when a custom winch/aero component is
+  present (see [`has_custom_component`](@ref)) and reuses the cache otherwise.
 - `reload`: force reloading the serialized model from disk.
 - `outputs`: vector of output variables (used by linearization / control funcs).
 - `create_prob`, `create_lin_prob`, `create_control_func`: which artefacts to build.
@@ -315,7 +338,7 @@ return a freshly initialized `ODEIntegrator`.
 """
 function init!(sam::SymbolicAWEModel;
     solver=nothing, adaptive=true, prn=true,
-    remake=false, reload=false,
+    remake=nothing, reload=false,
     outputs=nothing,
     create_prob::Bool=true,
     create_lin_prob::Bool=false,
@@ -333,6 +356,12 @@ function init!(sam::SymbolicAWEModel;
     sam.sys_struct isa SystemStructure || error(
         "Equation generation requires SystemStructure, " *
         "got $(typeof(sam.sys_struct)).")
+    if isnothing(remake)
+        remake = has_custom_component(sam.sys_struct)
+        remake && prn && @info "Custom winch/aero model detected; " *
+            "forcing remake (custom component equations are not " *
+            "captured by the model hash)."
+    end
     time = @elapsed begin
         if isnothing(solver)
             if sam.set.solver == "QNDF"
@@ -532,7 +561,8 @@ function get_sys_struct_hash(sys_struct::SystemStructure)
     for wing in wings
         wing_data = ("wing", wing.idx, wing.group_idxs,
                      Int(wing.dynamics_type),
-                     Int(wing.aero_mode))
+                     Int(wing.aero_mode),
+                     nameof(wing.aero_model))
 
         # Include wing reference points in hash
         if wing isa VSMWing || wing isa PlateWing

--- a/src/model_management.jl
+++ b/src/model_management.jl
@@ -290,14 +290,6 @@ function maybe_create_control_functions!(sam, outputs; create_control_func=false
     return false
 end
 
-"""
-    has_custom_component(sys_struct) -> Bool
-
-True if any winch or wing carries a user-supplied component builder
-whose equations are not captured by the model hash (a custom
-`winch.model`, or a wing with `aero_mode == AERO_CUSTOM`). Used by
-`init!` to default `remake=true` for such models.
-"""
 function has_custom_component(sys_struct)
     any(w.model !== default_winch_component
         for w in sys_struct.winches) && return true

--- a/src/model_management.jl
+++ b/src/model_management.jl
@@ -5,7 +5,7 @@ function make_psys_setter(sys)
     psys_params = filter(p -> endswith(string(p), "psys"), parameters(sys))
     setter = setp(sys, psys_params)
     n = length(psys_params)
-    return (prob, ss) -> setter(prob, ntuple(_ -> ss, n))
+    return (prob, sys_struct) -> setter(prob, ntuple(_ -> sys_struct, n))
 end
 
 """
@@ -24,13 +24,13 @@ of the compiled `ODESystem` (`sys`).
 - A `NamedTuple` containing various getter and setter functions for different parts of the system state.
 """
 function generate_prob_getters(sys_struct, sys)
-    c = collect
+    collect_each = collect
     (; wings, groups, pulleys, winches, tethers, segments) = sys_struct
     get_wing_state, get_aero_input, get_segment_state, get_group_state, get_pulley_state,
     get_winch_state, get_tether_state, set_set_values, get_set_values = ntuple(_ -> nothing, 9)
 
     if length(wings) > 0
-        wing_vars = c.([
+        wing_vars = collect_each.([
             sys.Q_b_to_w, sys.ω_b, sys.wing_pos,
             sys.wing_vel, sys.wing_acc,
             sys.va_wing_b, sys.wind_vel_wing,
@@ -52,25 +52,25 @@ function generate_prob_getters(sys_struct, sys)
 
         # aero_input only exists for RIGID_DYNAMICS + AERO_LINEARIZED wings
         has_linearized = any(
-            w.dynamics_type === RIGID_DYNAMICS &&
-            w.aero_mode === AERO_LINEARIZED
-            for w in sys_struct.wings)
+            wing.dynamics_type === RIGID_DYNAMICS &&
+            wing.aero_mode === AERO_LINEARIZED
+            for wing in sys_struct.wings)
         if has_linearized
             aero_inputs = [
-                getproperty(sys, Symbol("aero_$(w.idx)")).aero_input
-                for w in sys_struct.wings
-                if w.dynamics_type === RIGID_DYNAMICS &&
-                   w.aero_mode === AERO_LINEARIZED]
-            get_aero_input = getu(sys, c.(aero_inputs))
+                getproperty(sys, Symbol("aero_$(wing.idx)")).aero_input
+                for wing in sys_struct.wings
+                if wing.dynamics_type === RIGID_DYNAMICS &&
+                   wing.aero_mode === AERO_LINEARIZED]
+            get_aero_input = getu(sys, collect_each.(aero_inputs))
         else
             get_aero_input = nothing
         end
     end
-    if length(segments) > 0; get_segment_state = getu(sys, c.([sys.spring_force, sys.len, sys.l0])); end
-    if length(groups) > 0; get_group_state = getu(sys, c.([sys.twist_angle, sys.twist_ω, sys.group_tether_force, sys.group_tether_moment, sys.group_aero_moment])); end
-    if length(pulleys) > 0; get_pulley_state = getu(sys, c.([sys.pulley_len, sys.pulley_vel])); end
+    if length(segments) > 0; get_segment_state = getu(sys, collect_each.([sys.spring_force, sys.len, sys.l0])); end
+    if length(groups) > 0; get_group_state = getu(sys, collect_each.([sys.twist_angle, sys.twist_ω, sys.group_tether_force, sys.group_tether_moment, sys.group_aero_moment])); end
+    if length(pulleys) > 0; get_pulley_state = getu(sys, collect_each.([sys.pulley_len, sys.pulley_vel])); end
     if length(winches) > 0
-        get_winch_state = getu(sys, c.([
+        get_winch_state = getu(sys, collect_each.([
             sys.winch_acc, sys.winch_vel,
             sys.set_values, sys.winch_force_vec,
             sys.winch_friction]))
@@ -78,14 +78,14 @@ function generate_prob_getters(sys_struct, sys)
         get_set_values = getp(sys, sys.set_values)
     end
     if length(tethers) > 0
-        get_tether_state = getu(sys, c.([
+        get_tether_state = getu(sys, collect_each.([
             sys.tether_len,
             sys.stretched_len]))
     end
     set_sys = make_psys_setter(sys)
 
     # point_state always returns, in order: pos, vel, point_force, va_point_b, point_mass, total_drag
-    get_point_state = getu(sys, c.([sys.pos, sys.vel, sys.point_force, sys.va_point_b, sys.point_mass, sys.total_drag]))
+    get_point_state = getu(sys, collect_each.([sys.pos, sys.vel, sys.point_force, sys.va_point_b, sys.point_mass, sys.total_drag]))
 
     return (; get_wing_state, get_aero_input, get_segment_state, get_group_state,
             get_pulley_state, get_winch_state, get_tether_state, set_set_values,
@@ -135,11 +135,12 @@ function generate_control_funcs(model, inputs, outputs)
     (f_ip, f_oop), dvs, psym, io_sys = @suppress_err ModelingToolkit.generate_control_function(
         model, inputs; simplify=false
     )
-    nu, nx, ny = length(inputs), length(dvs), length(outputs)
+    num_inputs, num_states, num_outputs = length(inputs), length(dvs), length(outputs)
     (h_oop, h_ip) = ModelingToolkit.build_explicit_observed_function(
         io_sys, outputs; inputs, return_inplace=true
     )
-    return (f_oop=f_oop, f_ip=f_ip, h_oop=h_oop, h_ip=h_ip, nu=nu, nx=nx, ny=ny,
+    return (f_oop=f_oop, f_ip=f_ip, h_oop=h_oop, h_ip=h_ip,
+            nu=num_inputs, nx=num_states, ny=num_outputs,
             dvs=dvs, psym=psym, io_sys=io_sys)
 end
 
@@ -178,18 +179,18 @@ function load_serialized_model!(sam, model_path; remake=false, reload=false)
                 sam.serialized_model = serialized_model
                 return true
             end
-        catch e
-            bt = catch_backtrace()
+        catch exception
+            backtrace = catch_backtrace()
             log_path = model_path * ".error.log"
             open(log_path, "w") do io
                 println(io,
                     "Deserialization failed at ",
                     time())
                 println(io, "Path: $model_path")
-                showerror(io, e, bt)
+                showerror(io, exception, backtrace)
             end
             @warn "Failure to deserialize " *
-                "$model_path: $(typeof(e)). " *
+                "$model_path: $(typeof(exception)). " *
                 "Details in $log_path"
         end
     end
@@ -305,10 +306,10 @@ Return `true` when the system has a non-default winch model or a wing using
 must be rebuilt.
 """
 function has_custom_component(sys_struct)
-    any(w.model !== default_winch_component
-        for w in sys_struct.winches) && return true
-    any(w.aero_mode == AERO_CUSTOM
-        for w in sys_struct.wings) && return true
+    any(winch.model !== default_winch_component
+        for winch in sys_struct.winches) && return true
+    any(wing.aero_mode == AERO_CUSTOM
+        for wing in sys_struct.wings) && return true
     return false
 end
 
@@ -517,12 +518,12 @@ This is used to check if a cached compiled model is still valid.
 function get_set_hash(set::Settings;
         fields=[:segments, :model, :foil_file, :physical_model, :quasi_static, :winch_model]
     )
-    h = zeros(UInt8, 1)
+    hash_acc = zeros(UInt8, 1)
     for field in fields
         value = getfield(set, field)
-        h = sha1(string((value, h)))
+        hash_acc = sha1(string((value, hash_acc)))
     end
-    return h
+    return hash_acc
 end
 
 """
@@ -572,11 +573,11 @@ function get_sys_struct_hash(sys_struct::SystemStructure)
 
         # Include wing reference points in hash
         if wing isa VSMWing || wing isa PlateWing
-            _ref_hash(r) = (r.ids, r.weights)
-            _rp_hash(rp) = isnothing(rp) ? nothing :
-                (_ref_hash(rp[1]), _ref_hash(rp[2]))
-            _origin_hash(o) = isnothing(o) ? nothing :
-                _ref_hash(o)
+            _ref_hash(ref) = (ref.ids, ref.weights)
+            _rp_hash(ref_points) = isnothing(ref_points) ? nothing :
+                (_ref_hash(ref_points[1]), _ref_hash(ref_points[2]))
+            _origin_hash(origin) = isnothing(origin) ? nothing :
+                _ref_hash(origin)
             wing_data = (wing_data...,
                 _rp_hash(wing.z_ref_points),
                 _rp_hash(wing.y_ref_points),

--- a/src/model_management.jl
+++ b/src/model_management.jl
@@ -16,6 +16,13 @@ of the compiled `ODESystem` (`sys`).
 # Returns
 - A `NamedTuple` containing various getter and setter functions for different parts of the system state.
 """
+function make_psys_setter(sys)
+    psys_params = filter(p -> endswith(string(p), "psys"), parameters(sys))
+    setter = setp(sys, psys_params)
+    n = length(psys_params)
+    return (prob, ss) -> setter(prob, ntuple(_ -> ss, n))
+end
+
 function generate_prob_getters(sys_struct, sys)
     c = collect
     (; wings, groups, pulleys, winches, tethers, segments) = sys_struct
@@ -75,7 +82,7 @@ function generate_prob_getters(sys_struct, sys)
             sys.tether_len,
             sys.stretched_len]))
     end
-    set_sys = setp(sys, sys.psys)
+    set_sys = make_psys_setter(sys)
 
     # point_state always returns, in order: pos, vel, point_force, va_point_b, point_mass, total_drag
     get_point_state = getu(sys, c.([sys.pos, sys.vel, sys.point_force, sys.va_point_b, sys.point_mass, sys.total_drag]))
@@ -102,7 +109,7 @@ function generate_lin_getters(sys)
     if hasproperty(sys, :set_values)
         set_set_values = setp(sys, sys.set_values)
     end
-    set_sys = setp(sys, sys.psys)
+    set_sys = make_psys_setter(sys)
     return (; set_set_values, set_sys)
 end
 

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -76,14 +76,14 @@ function sim!(
             if step < steps ÷ 2
                 step_time, integ_time, vsm_time = 0.0, 0.0, 0.0
             end
-        catch e
-            if e isa AssertionError
+        catch exception
+            if exception isa AssertionError
                 if prn
                     @warn "Crashed at t=$t"
                 end
                 break
             else
-                rethrow(e)
+                rethrow(exception)
             end
         end
         update_sys_state!(sys_state, sam)
@@ -92,7 +92,7 @@ function sim!(
     end
 
     # --- Linear Simulation ---
-    lin_lg = nothing
+    lin_sim_log = nothing
     if !isnothing(lin_model)
         isnothing(y_op) && error(
             "y_op (operating point output) is required " *
@@ -117,12 +117,12 @@ function sim!(
             log!(lin_logger, lin_sys_state)
         end
         save_log(lin_logger, "tmp_run_lin")
-        lin_lg = load_log("tmp_run_lin")
+        lin_sim_log = load_log("tmp_run_lin")
     end
 
     mkpath(get_data_path())
     save_log(logger, "tmp_run")
-    lg = load_log("tmp_run")
+    sim_log = load_log("tmp_run")
     
     if prn
         lines = [
@@ -137,7 +137,7 @@ function sim!(
         @info join(lines, "\n")
     end
 
-    return (lg, lin_lg)
+    return (sim_log, lin_sim_log)
 end
 
 """
@@ -263,52 +263,52 @@ Construct a SysState for logging linear state-space simulation output y (ordered
 sam.outputs).
 """
 function make_lin_sys_state(y::AbstractVector, sam::SymbolicAWEModel, t::Real)
-    ss = SysState(sam)
-    update_sys_state!(ss, y, sam, t)
-    return ss
+    sys_state = SysState(sam)
+    update_sys_state!(sys_state, y, sam, t)
+    return sys_state
 end
 
 """
-    update_sys_state!(ss, y::AbstractVector, sam::SymbolicAWEModel, t::Real)
+    update_sys_state!(sys_state, y::AbstractVector, sam::SymbolicAWEModel, t::Real)
 
 Update a SysState for a linear state-space simulation, using output y and model sam.
 """
-function update_sys_state!(ss, y::AbstractVector, sam::SymbolicAWEModel, t::Real)
+function update_sys_state!(sys_state, y::AbstractVector, sam::SymbolicAWEModel, t::Real)
     sys = sam.prob.sys
     outputs = sam.outputs
     for (i, sym) in enumerate(outputs)
         if isequal(sym, sys.heading[1])
-            ss.heading = y[i]
+            sys_state.heading = y[i]
         elseif isequal(sym, sys.turn_rate[3, 1])
-            ss.turn_rates[1,3] = y[i]
+            sys_state.turn_rates[1,3] = y[i]
         elseif isequal(sym, sys.tether_len[1])
-            ss.l_tether[1] = y[i]
+            sys_state.l_tether[1] = y[i]
         elseif isequal(sym, sys.tether_len[2])
-            ss.l_tether[2] = y[i]
+            sys_state.l_tether[2] = y[i]
         elseif isequal(sym, sys.tether_len[3])
-            ss.l_tether[3] = y[i]
+            sys_state.l_tether[3] = y[i]
         elseif isequal(sym, sys.winch_vel[1])
-            ss.v_reelout[1] = y[i]
+            sys_state.v_reelout[1] = y[i]
         elseif isequal(sym, sys.winch_vel[2])
-            ss.v_reelout[2] = y[i]
+            sys_state.v_reelout[2] = y[i]
         elseif isequal(sym, sys.winch_vel[3])
-            ss.v_reelout[3] = y[i]
+            sys_state.v_reelout[3] = y[i]
         elseif isequal(sym, sys.winch_force[1])
-            ss.winch_force[1] = y[i]
+            sys_state.winch_force[1] = y[i]
         elseif isequal(sym, sys.winch_force[2])
-            ss.winch_force[2] = y[i]
+            sys_state.winch_force[2] = y[i]
         elseif isequal(sym, sys.winch_force[3])
-            ss.winch_force[3] = y[i]
+            sys_state.winch_force[3] = y[i]
         elseif isequal(sym, sys.angle_of_attack[1])
-            ss.AoA = mod(y[i] + π, 2π) - π  # Wrap to [-π, π]
+            sys_state.AoA = mod(y[i] + π, 2π) - π  # Wrap to [-π, π]
         elseif isequal(sym, sys.elevation[1])
-            ss.elevation = y[i]
+            sys_state.elevation = y[i]
         elseif isequal(sym, sys.azimuth[1])
-            ss.azimuth = y[i]
+            sys_state.azimuth = y[i]
         elseif isequal(sym, sys.course[1])
-            ss.course = y[i]
+            sys_state.course = y[i]
         end
     end
-    ss.time = t
-    return ss
+    sys_state.time = t
+    return sys_state
 end

--- a/src/system_structure/system_structure_core.jl
+++ b/src/system_structure/system_structure_core.jl
@@ -251,7 +251,7 @@ function resolve_ref_spec(spec::Union{Int, Symbol}, name_dict::Dict{Symbol, Int6
 end
 
 function resolve_ref_spec(spec::AbstractVector, name_dict::Dict{Symbol, Int64}, component_type::String)
-    return Int64[resolve_ref(r, name_dict, component_type) for r in spec]
+    return Int64[resolve_ref(ref, name_dict, component_type) for ref in spec]
 end
 
 function resolve_ref_spec(::Nothing, ::Dict{Symbol, Int64}, ::String)
@@ -271,8 +271,8 @@ function resolve!(
 )
     isempty(ref_pt.refs) && return
     ref_pt.ids = Int64[
-        resolve_ref(r, name_dict, component_type)
-        for r in ref_pt.refs]
+        resolve_ref(ref, name_dict, component_type)
+        for ref in ref_pt.refs]
 end
 
 """
@@ -291,20 +291,20 @@ function expand_auto_tethers!(
     set::Settings
 )
     # Build point name lookup for finding start/end points
-    pt_names = Dict{Symbol, Int}()
-    for (i, p) in enumerate(points)
-        if !isnothing(p.name)
-            nm = p.name isa Symbol ? p.name : Symbol(p.name)
-            pt_names[nm] = i
+    point_names = Dict{Symbol, Int}()
+    for (i, point) in enumerate(points)
+        if !isnothing(point.name)
+            name = point.name isa Symbol ? point.name : Symbol(point.name)
+            point_names[name] = i
         end
     end
 
     # Build segment name set for checking existing segments
     seg_names = Set{Symbol}()
-    for s in segments
-        if !isnothing(s.name)
-            nm = s.name isa Symbol ? s.name : Symbol(s.name)
-            push!(seg_names, nm)
+    for segment in segments
+        if !isnothing(segment.name)
+            name = segment.name isa Symbol ? segment.name : Symbol(segment.name)
+            push!(seg_names, name)
         end
     end
 
@@ -319,55 +319,57 @@ function expand_auto_tethers!(
         first_seg_sym in seg_names && continue
 
         # Resolve start and end points by name
-        sp_sym = tether.start_point_ref isa Symbol ?
+        start_point_sym = tether.start_point_ref isa Symbol ?
             tether.start_point_ref :
             Symbol(tether.start_point_ref)
-        ep_sym = tether.end_point_ref isa Symbol ?
+        end_point_sym = tether.end_point_ref isa Symbol ?
             tether.end_point_ref :
             Symbol(tether.end_point_ref)
-        haskey(pt_names, sp_sym) || error(
+        haskey(point_names, start_point_sym) || error(
             "Tether $(tether.name): start_point " *
-            ":$sp_sym not found in points")
-        haskey(pt_names, ep_sym) || error(
+            ":$start_point_sym not found in points")
+        haskey(point_names, end_point_sym) || error(
             "Tether $(tether.name): end_point " *
-            ":$ep_sym not found in points")
-        sp_idx = pt_names[sp_sym]
-        ep_idx = pt_names[ep_sym]
-        start_pos = points[sp_idx].pos_cad
-        end_pos = points[ep_idx].pos_cad
+            ":$end_point_sym not found in points")
+        start_point_idx = point_names[start_point_sym]
+        end_point_idx = point_names[end_point_sym]
+        start_pos = points[start_point_idx].pos_cad
+        end_pos = points[end_point_idx].pos_cad
 
         # Inherit transform from endpoints
-        sp_tf = points[sp_idx].transform_ref
-        ep_tf = points[ep_idx].transform_ref
-        sp_has_tf = sp_tf != 0
-        ep_has_tf = ep_tf != 0
-        if sp_has_tf && ep_has_tf && sp_tf != ep_tf
+        start_transform = points[start_point_idx].transform_ref
+        end_transform = points[end_point_idx].transform_ref
+        start_has_transform = start_transform != 0
+        end_has_transform = end_transform != 0
+        if start_has_transform && end_has_transform &&
+           start_transform != end_transform
             error("Tether $(tether.name): " *
-                "start_point :$sp_sym (transform=" *
-                "$sp_tf) and end_point :$ep_sym " *
-                "(transform=$ep_tf) have different " *
+                "start_point :$start_point_sym (transform=" *
+                "$start_transform) and end_point :$end_point_sym " *
+                "(transform=$end_transform) have different " *
                 "transforms")
         end
-        tf = sp_has_tf ? sp_tf : ep_has_tf ? ep_tf : 0
+        transform_idx = start_has_transform ? start_transform :
+            end_has_transform ? end_transform : 0
 
         n = tether.n_segments
 
         # Derive segment properties from settings if NaN
-        us = tether.unit_stiffness
-        ud = tether.unit_damping
-        d = tether.diameter
-        if isnan(d)
-            d = set.d_tether * 0.001  # mm → m
+        unit_stiffness = tether.unit_stiffness
+        unit_damping = tether.unit_damping
+        diameter = tether.diameter
+        if isnan(diameter)
+            diameter = set.d_tether * 0.001  # mm → m
         end
-        if isnan(us)
-            us = set.e_tether * (d / 2)^2 * π
+        if isnan(unit_stiffness)
+            unit_stiffness = set.e_tether * (diameter / 2)^2 * π
         end
-        if isnan(ud)
+        if isnan(unit_damping)
             if hasproperty(set, :rel_damping) &&
                set.rel_damping != 0.0
-                ud = set.rel_damping * us
+                unit_damping = set.rel_damping * unit_stiffness
             else
-                ud = 0.0
+                unit_damping = 0.0
             end
         end
 
@@ -378,16 +380,16 @@ function expand_auto_tethers!(
 
         # Generate n-1 intermediate DYNAMIC points
         # (placed along the straight line at geometric spacing)
-        dir = end_pos - start_pos
+        direction = end_pos - start_pos
         for i in 1:(n - 1)
             frac = i / n
-            pos = start_pos + frac * dir
-            pt_name = Symbol("$(tether.name)_point_$i")
-            tf_kw = tf == 0 ? () :
-                (transform=tf,)
-            push!(points, Point(pt_name, pos,
-                DYNAMIC; tf_kw...))
-            pt_names[pt_name] = length(points)
+            pos = start_pos + frac * direction
+            point_name = Symbol("$(tether.name)_point_$i")
+            transform_kw = transform_idx == 0 ? () :
+                (transform=transform_idx,)
+            push!(points, Point(point_name, pos,
+                DYNAMIC; transform_kw...))
+            point_names[point_name] = length(points)
         end
 
         # Generate n segments
@@ -396,19 +398,20 @@ function expand_auto_tethers!(
             seg_sym = seg_name isa Symbol ? seg_name :
                 Symbol(seg_name)
             if i == 1
-                p_i = tether.start_point_ref
+                start_ref = tether.start_point_ref
             else
-                p_i = Symbol(
+                start_ref = Symbol(
                     "$(tether.name)_point_$(i - 1)")
             end
             if i == n
-                p_j = tether.end_point_ref
+                end_ref = tether.end_point_ref
             else
-                p_j = Symbol(
+                end_ref = Symbol(
                     "$(tether.name)_point_$i")
             end
             push!(segments, Segment(
-                seg_sym, p_i, p_j, us, ud, d;
+                seg_sym, start_ref, end_ref,
+                unit_stiffness, unit_damping, diameter;
                 l0=seg_l0))
             push!(seg_names, seg_sym)
         end
@@ -477,28 +480,28 @@ function assign_indices_and_resolve!(
 
     # Groups: resolve point_refs
     for group in groups
-        group.point_idxs = Int64[resolve_ref(r, point_names, "point") for r in group.point_refs]
+        group.point_idxs = Int64[resolve_ref(ref, point_names, "point") for ref in group.point_refs]
     end
 
     # Segments: resolve point_refs
     for segment in segments
-        p1 = resolve_ref(segment.point_refs[1], point_names, "point")
-        p2 = resolve_ref(segment.point_refs[2], point_names, "point")
-        segment.point_idxs = (p1, p2)
+        point1 = resolve_ref(segment.point_refs[1], point_names, "point")
+        point2 = resolve_ref(segment.point_refs[2], point_names, "point")
+        segment.point_idxs = (point1, point2)
     end
 
     # Pulleys: resolve segment_refs
     for pulley in pulleys
-        s1 = resolve_ref(pulley.segment_refs[1], segment_names, "segment")
-        s2 = resolve_ref(pulley.segment_refs[2], segment_names, "segment")
-        pulley.segment_idxs = (s1, s2)
+        segment1 = resolve_ref(pulley.segment_refs[1], segment_names, "segment")
+        segment2 = resolve_ref(pulley.segment_refs[2], segment_names, "segment")
+        pulley.segment_idxs = (segment1, segment2)
     end
 
     # Tethers: resolve segment_refs and start/end point refs
     for tether in tethers
         tether.segment_idxs = Int64[
-            resolve_ref(r, segment_names, "segment")
-            for r in tether.segment_refs]
+            resolve_ref(ref, segment_names, "segment")
+            for ref in tether.segment_refs]
         if !isnothing(tether.start_point_ref)
             tether.start_point_idx = resolve_ref(
                 tether.start_point_ref, point_names, "point")
@@ -512,8 +515,8 @@ function assign_indices_and_resolve!(
     # Winches: resolve tether_refs and winch_point_ref
     for winch in winches
         winch.tether_idxs = Int64[
-            resolve_ref(r, tether_names, "tether")
-            for r in winch.tether_refs]
+            resolve_ref(ref, tether_names, "tether")
+            for ref in winch.tether_refs]
         winch.winch_point_idx = resolve_ref(
             winch.winch_point_ref, point_names, "point")
     end
@@ -531,7 +534,7 @@ function assign_indices_and_resolve!(
     # Wings: resolve group_refs, transform_ref, and PARTICLE_DYNAMICS-specific refs
     for wing in wings
         # BaseWing fields
-        wing.group_idxs = Int64[resolve_ref(r, group_names, "group") for r in wing.group_refs]
+        wing.group_idxs = Int64[resolve_ref(ref, group_names, "group") for ref in wing.group_refs]
         wing.transform_idx = resolve_ref(wing.transform_ref, transform_names, "transform")
 
         # VSMWing-specific fields
@@ -557,21 +560,21 @@ function assign_indices_and_resolve!(
             # n_unrefined as proxy which may differ)
             if wing.dynamics_type == RIGID_DYNAMICS
                 n_grp = length(wing.group_idxs)
-                nx = 6 + n_grp
-                ny = 5 + n_grp
-                if length(wing.aero_x) != nx ||
-                        length(wing.aero_y) != ny
-                    wing.aero_y = zeros(SimFloat, ny)
-                    wing.aero_x = zeros(SimFloat, nx)
+                num_aero_outputs = 6 + n_grp
+                num_aero_inputs = 5 + n_grp
+                if length(wing.aero_x) != num_aero_outputs ||
+                        length(wing.aero_y) != num_aero_inputs
+                    wing.aero_y = zeros(SimFloat, num_aero_inputs)
+                    wing.aero_x = zeros(SimFloat, num_aero_outputs)
                     wing.aero_jac = zeros(
-                        SimFloat, nx, ny)
+                        SimFloat, num_aero_outputs, num_aero_inputs)
                 end
             end
         end
         if isa(wing, PlateWing)
-            for surf in wing.surfaces
-                surf.point_idx = resolve_ref(
-                    surf.point_ref, point_names, "point")
+            for surface in wing.surfaces
+                surface.point_idx = resolve_ref(
+                    surface.point_ref, point_names, "point")
             end
         end
     end
@@ -599,9 +602,9 @@ function init_body_frame_from_ref_points!(
 
     # Temporarily set pos_w = pos_cad so
     # calc_particle_dynamics_wing_frame can read positions
-    for p in points
-        p.type == WING && p.wing_idx == wing.idx &&
-            (p.pos_w .= p.pos_cad)
+    for point in points
+        point.type == WING && point.wing_idx == wing.idx &&
+            (point.pos_w .= point.pos_cad)
     end
     R_b_to_c, _ = calc_particle_dynamics_wing_frame(
         points, wing.z_ref_points,
@@ -610,9 +613,9 @@ function init_body_frame_from_ref_points!(
     wing.R_b_to_p .= Matrix{SimFloat}(I, 3, 3)
 
     if prn
-        o = round.(origin_pos; digits=3)
+        origin_rounded = round.(origin_pos; digits=3)
         @info "Wing $(wing.name) ($(typeof(wing).name.name))" *
-              ": origin=[$o]"
+              ": origin=[$origin_rounded]"
     end
 end
 
@@ -698,20 +701,20 @@ function compute_spatial_group_mapping!(
     end
 
     # Assign each unrefined section to nearest group
-    for s in 1:n_unrefined
+    for section_idx in 1:n_unrefined
         min_dist = Inf
         closest_local = 1
         for local_idx in 1:n_groups
-            d = norm(unrefined_centers[s] -
+            dist = norm(unrefined_centers[section_idx] -
                      group_centers[local_idx])
-            if d < min_dist
-                min_dist = d
+            if dist < min_dist
+                min_dist = dist
                 closest_local = local_idx
             end
         end
         g_idx = the_wing.base.group_idxs[closest_local]
         push!(groups[g_idx].unrefined_section_idxs,
-              Int64(s))
+              Int64(section_idx))
     end
 
     # Every group must claim at least one section
@@ -772,7 +775,7 @@ function SystemStructure(name, set;
         prn::Bool=true,
     )
     # Load VSMSettings if not provided and VSM wings exist
-    has_vsm_wings = any(w isa VSMWing for w in wings)
+    has_vsm_wings = any(wing isa VSMWing for wing in wings)
     if isnothing(vsm_set) && has_vsm_wings
         model_dir = get_data_path()
         vsm_set_path = joinpath(model_dir, "vsm_settings.yaml")
@@ -812,7 +815,7 @@ function SystemStructure(name, set;
 
     # If no wings defined, convert WING points to STATIC
     if isempty(wings)
-        wing_point_idxs = findall(p -> p.type == WING, points)
+        wing_point_idxs = findall(point -> point.type == WING, points)
         if !isempty(wing_point_idxs)
             @warn "No wings provided but " *
                   "$(length(wing_point_idxs)) WING type " *
@@ -867,11 +870,11 @@ function SystemStructure(name, set;
         end
     end
     for wing in wings
-        wing_point_idxs = [p.idx for p in points
-            if p.type == WING && p.wing_idx == wing.idx]
+        wing_point_idxs = [point.idx for point in points
+            if point.type == WING && point.wing_idx == wing.idx]
         point_mass_sum = sum(
-            p.extra_mass for p in points
-            if p.type == WING && p.wing_idx == wing.idx; init=0.0)
+            point.extra_mass for point in points
+            if point.type == WING && point.wing_idx == wing.idx; init=0.0)
         set_mass = hasproperty(set, :mass) ? set.mass : 0.0
 
         if set_mass > 0 && point_mass_sum > 0
@@ -906,12 +909,12 @@ function SystemStructure(name, set;
         vsm_wing = wing.vsm_wing
 
         if wing.dynamics_type == RIGID_DYNAMICS
-            wing_pts = [p for p in points
-                if p.type == WING &&
-                   p.wing_idx == wing.idx]
-            isempty(wing_pts) && continue
+            wing_points = [point for point in points
+                if point.type == WING &&
+                   point.wing_idx == wing.idx]
+            isempty(wing_points) && continue
 
-            masses = [p.extra_mass for p in wing_pts]
+            masses = [point.extra_mass for point in wing_points]
             total_m = sum(masses)
 
             # Mesh tensor is per-unit-mass; its COM is -T_cad_body.
@@ -920,15 +923,15 @@ function SystemStructure(name, set;
                 I_cad = wing.mass .* vsm_wing.inertia_tensor
             else
                 com_cad = total_m > 0 ?
-                    sum(masses[j] .* wing_pts[j].pos_cad
-                        for j in eachindex(wing_pts)) / total_m :
-                    mean([p.pos_cad for p in wing_pts])
+                    sum(masses[j] .* wing_points[j].pos_cad
+                        for j in eachindex(wing_points)) / total_m :
+                    mean([point.pos_cad for point in wing_points])
                 I_cad = nothing
                 if total_m > 0
                     I_cad = zeros(3, 3)
-                    for (m, p) in zip(masses, wing_pts)
-                        r = p.pos_cad - com_cad
-                        I_cad += m * (dot(r, r) * I(3) - r * r')
+                    for (mass, point) in zip(masses, wing_points)
+                        r = point.pos_cad - com_cad
+                        I_cad += mass * (dot(r, r) * I(3) - r * r')
                     end
                 end
             end
@@ -947,10 +950,10 @@ function SystemStructure(name, set;
                 wing.pos_cad .= origin_cad
 
                 # Temporarily set pos_w = pos_cad
-                for p in points
-                    p.type == WING &&
-                        p.wing_idx == wing.idx &&
-                        (p.pos_w .= p.pos_cad)
+                for point in points
+                    point.type == WING &&
+                        point.wing_idx == wing.idx &&
+                        (point.pos_w .= point.pos_cad)
                 end
                 R_b_to_c, _ = calc_particle_dynamics_wing_frame(
                     points, wing.z_ref_points,
@@ -986,12 +989,12 @@ function SystemStructure(name, set;
             if prn
                 I_rnd = round.(wing.inertia_principal;
                                digits=4)
-                off = round.(wing.com_offset_b;
+                offset_rounded = round.(wing.com_offset_b;
                              digits=4)
                 @info "RIGID_DYNAMICS wing $(wing.idx):" *
                     " COM=[$(round.(com_cad; digits=3))]" *
                     ", I=$I_rnd" *
-                    ", com_offset_b=$off"
+                    ", com_offset_b=$offset_rounded"
             end
 
         elseif wing.dynamics_type == PARTICLE_DYNAMICS
@@ -1027,7 +1030,7 @@ function SystemStructure(name, set;
            wing.aero_mode != AERO_NONE
             # Get WING-type points for this wing
             wing_point_idxs = findall(
-                p -> p.type == WING && p.wing_idx == wing.idx, points)
+                point -> point.type == WING && point.wing_idx == wing.idx, points)
             wing_points = [points[idx] for idx in wing_point_idxs]
 
             # Identify LE/TE pairs
@@ -1060,11 +1063,11 @@ function SystemStructure(name, set;
 
             # Resize aero arrays for new group count
             n_groups = length(new_group_idxs)
-            nx = 6 + n_groups
-            ny = 5 + n_groups
-            wing.aero_y = zeros(SimFloat, ny)
-            wing.aero_x = zeros(SimFloat, nx)
-            wing.aero_jac = zeros(SimFloat, nx, ny)
+            num_aero_outputs = 6 + n_groups
+            num_aero_inputs = 5 + n_groups
+            wing.aero_y = zeros(SimFloat, num_aero_inputs)
+            wing.aero_x = zeros(SimFloat, num_aero_outputs)
+            wing.aero_jac = zeros(SimFloat, num_aero_outputs, num_aero_inputs)
 
             prn && @info "Auto-created $(length(new_group_idxs)) groups " *
                   "for RIGID_DYNAMICS wing $(wing.idx)"
@@ -1115,20 +1118,20 @@ function SystemStructure(name, set;
             n_sec = length(sections)
             ksec = argmin([
                 norm(center -
-                    (Vector(s.LE_point) +
-                     Vector(s.TE_point)) / 2)
-                for s in sections])
+                    (Vector(section.LE_point) +
+                     Vector(section.TE_point)) / 2)
+                for section in sections])
             le_sec = Vector(sections[ksec].LE_point)
             te_sec = Vector(sections[ksec].TE_point)
-            ly = zeros(3)
-            ksec > 1 && (ly += normalize(
+            span_dir = zeros(3)
+            ksec > 1 && (span_dir += normalize(
                 Vector(sections[ksec - 1].LE_point) - le_sec))
-            ksec < n_sec && (ly += normalize(
+            ksec < n_sec && (span_dir += normalize(
                 le_sec - Vector(sections[ksec + 1].LE_point)))
 
             group.le_pos .= le_sec
             group.chord .= te_sec - le_sec
-            group.y_airf .= normalize(ly)
+            group.y_airf .= normalize(span_dir)
             break
         end
     end
@@ -1152,7 +1155,7 @@ function SystemStructure(name, set;
             if isnothing(wing.point_to_vsm_point)
                 # Get WING-type points for this wing
                 wing_point_idxs = findall(
-                    p -> p.type == WING && p.wing_idx == wing.idx, points)
+                    point -> point.type == WING && point.wing_idx == wing.idx, points)
                 wing_points = [points[idx]
                     for idx in wing_point_idxs]
                 wing.point_to_vsm_point =
@@ -1197,15 +1200,15 @@ function SystemStructure(name, set;
         # Use number of unrefined sections
         first_wing = wings[1]
         n_unrefined = first_wing isa VSMWing ? first_wing.vsm_wing.n_unrefined_sections : 0
-        ny = 3 + n_unrefined + 3
-        nx = 3 + 3 + n_unrefined
+        num_aero_inputs = 3 + n_unrefined + 3
+        num_aero_outputs = 3 + 3 + n_unrefined
     else
-        ny = 0
-        nx = 0
+        num_aero_inputs = 0
+        num_aero_outputs = 0
     end
-    y = zeros(length(wings), ny)
-    x = zeros(length(wings), nx)
-    jac = zeros(length(wings), nx, ny)
+    y = zeros(length(wings), num_aero_inputs)
+    x = zeros(length(wings), num_aero_outputs)
+    jac = zeros(length(wings), num_aero_outputs, num_aero_inputs)
     set.physical_model = name
 
     # Name dictionaries were already built by assign_indices_and_resolve!
@@ -1224,9 +1227,9 @@ function SystemStructure(name, set;
     # Recalculate segment rest lengths from current positions if requested
     if ignore_l0
         for segment in sys_struct.segments
-            p1 = sys_struct.points[segment.point_idxs[1]]
-            p2 = sys_struct.points[segment.point_idxs[2]]
-            segment.l0 = norm(p2.pos_w - p1.pos_w)
+            point1 = sys_struct.points[segment.point_idxs[1]]
+            point2 = sys_struct.points[segment.point_idxs[2]]
+            segment.l0 = norm(point2.pos_w - point1.pos_w)
         end
     end
 

--- a/src/system_structure/types.jl
+++ b/src/system_structure/types.jl
@@ -74,12 +74,14 @@ Orthogonal to WingType — determines the aero computation strategy at runtime.
 - `AERO_DIRECT`: Stored forces from nonlinear VSM solve, piecewise-constant between updates.
 - `AERO_LINEARIZED`: First-order Taylor expansion using Jacobian from VSM linearization.
 - `AERO_PLATE`: Flat-plate CL/CD lookup aerodynamics (PlateWing only).
+- `AERO_CUSTOM`: User-supplied aero component (see `wing.aero_model`).
 """
 @enum AeroMode begin
     AERO_NONE
     AERO_DIRECT
     AERO_LINEARIZED
     AERO_PLATE
+    AERO_CUSTOM
 end
 
 """

--- a/src/system_structure/types.jl
+++ b/src/system_structure/types.jl
@@ -701,6 +701,10 @@ mutable struct Winch
     `winch_vel` and `tether_len` when `> 0.5`; custom components
     may interpret intermediate values as a continuous brake."""
     brake::SimFloat
+    """If true, reel-out velocity is prescribed externally rather
+    than integrated from motor dynamics: winch acceleration is forced
+    to 0 (ignoring `model`). Set the velocity via `winch.vel`."""
+    speed_controlled::Bool
     "Force vector at winch point [N]."
     const force::KVec3
     "Gear ratio [-]."
@@ -741,6 +745,9 @@ torque or speed regulation.
 - `init_vel::SimFloat=0.0`: Initial reel-out rate [m/s].
 - `brake=0.0`: Brake input in [0, 1]. `> 0.5` engages a hard
   freeze on `winch_vel` and `tether_len` at the outer integrator.
+- `speed_controlled::Bool=false`: If true, prescribe reel-out
+  velocity via `winch.vel` instead of integrating motor dynamics;
+  winch acceleration is forced to 0, ignoring `model`.
 - `friction_epsilon::SimFloat=6.0`: Smoothing parameter for
   Coulomb friction sign function.
 - `model::Function=default_winch_component`: Builder returning
@@ -749,7 +756,7 @@ torque or speed regulation.
 """
 function Winch(name, set::Settings, tethers;
                winch_point,
-               init_vel=0.0, brake=0.0,
+               init_vel=0.0, brake=0.0, speed_controlled=false,
                friction_epsilon=6.0,
                model::Function=default_winch_component)
     tether_refs = Vector{NameRef}(
@@ -759,7 +766,7 @@ function Winch(name, set::Settings, tethers;
     return Winch(0, name, Int64[], tether_refs, 0, wp,
                  init_vel, 0.0,
                  0.0, 0.0,
-                 SimFloat(brake), zeros(KVec3),
+                 SimFloat(brake), speed_controlled, zeros(KVec3),
                  set.gear_ratio, set.drum_radius,
                  set.f_coulomb, set.c_vf,
                  set.inertia_total, zero(SimFloat),
@@ -785,7 +792,7 @@ Constructs a `Winch` by directly providing physical parameters.
 function Winch(name, tethers, gear_ratio, drum_radius,
                f_coulomb, c_vf, inertia_total;
                winch_point,
-               init_vel=0.0, brake=0.0,
+               init_vel=0.0, brake=0.0, speed_controlled=false,
                friction_epsilon=6.0,
                model::Function=default_winch_component)
     tether_refs = Vector{NameRef}(
@@ -795,7 +802,7 @@ function Winch(name, tethers, gear_ratio, drum_radius,
     return Winch(0, name, Int64[], tether_refs, 0, wp,
                  init_vel, 0.0,
                  0.0, 0.0,
-                 SimFloat(brake), zeros(KVec3),
+                 SimFloat(brake), speed_controlled, zeros(KVec3),
                  gear_ratio, drum_radius, f_coulomb,
                  c_vf, inertia_total, zero(SimFloat),
                  friction_epsilon, model)

--- a/src/system_structure/utilities.jl
+++ b/src/system_structure/utilities.jl
@@ -20,9 +20,9 @@ This file contains:
 Compute segment length from endpoint `pos_cad` positions.
 """
 function segment_cad_length(segment::Segment, points)
-    p1 = points[segment.point_idxs[1]]
-    p2 = points[segment.point_idxs[2]]
-    return norm(p1.pos_cad - p2.pos_cad)
+    point1 = points[segment.point_idxs[1]]
+    point2 = points[segment.point_idxs[2]]
+    return norm(point1.pos_cad - point2.pos_cad)
 end
 
 """
@@ -31,9 +31,9 @@ end
 Compute segment length from endpoint `pos_w` positions.
 """
 function segment_world_length(segment::Segment, points)
-    p1 = points[segment.point_idxs[1]]
-    p2 = points[segment.point_idxs[2]]
-    return norm(p1.pos_w - p2.pos_w)
+    point1 = points[segment.point_idxs[1]]
+    point2 = points[segment.point_idxs[2]]
+    return norm(point1.pos_w - point2.pos_w)
 end
 
 
@@ -266,14 +266,14 @@ Returns `(nothing, nothing)` if neither endpoint is on a boundary;
 errors if both are.
 """
 function tether_anchor_free(tether, boundary)
-    s_in = tether.start_point_idx in boundary
-    e_in = tether.end_point_idx in boundary
-    if s_in && e_in
+    start_on_boundary = tether.start_point_idx in boundary
+    end_on_boundary = tether.end_point_idx in boundary
+    if start_on_boundary && end_on_boundary
         error("Tether $(tether.name): both endpoints are " *
               "ground-fixed; cannot place it to a length.")
-    elseif s_in
+    elseif start_on_boundary
         return tether.start_point_idx, tether.end_point_idx
-    elseif e_in
+    elseif end_on_boundary
         return tether.end_point_idx, tether.start_point_idx
     end
     return nothing, nothing
@@ -291,10 +291,10 @@ function rigid_point_siblings(points, wings)
     siblings = Dict{Int64, Set{Int64}}()
     for wing in wings
         wing.dynamics_type == RIGID_DYNAMICS || continue
-        members = Set{Int64}(p.idx for p in points
-            if p.type == WING && p.wing_idx == wing.idx)
-        for m in members
-            siblings[m] = members
+        members = Set{Int64}(point.idx for point in points
+            if point.type == WING && point.wing_idx == wing.idx)
+        for member in members
+            siblings[member] = members
         end
     end
     return siblings
@@ -322,16 +322,16 @@ function tether_downstream_idxs(tether, segments, boundary,
         neighbors = Int64[]
         for seg in segments
             seg.idx in tether_segment_set && continue
-            p1, p2 = seg.point_idxs
-            if p1 == current_idx
-                push!(neighbors, p2)
-            elseif p2 == current_idx
-                push!(neighbors, p1)
+            point_idx1, point_idx2 = seg.point_idxs
+            if point_idx1 == current_idx
+                push!(neighbors, point_idx2)
+            elseif point_idx2 == current_idx
+                push!(neighbors, point_idx1)
             end
         end
         if haskey(rigid_siblings, current_idx)
-            for sib in rigid_siblings[current_idx]
-                sib == current_idx || push!(neighbors, sib)
+            for sibling in rigid_siblings[current_idx]
+                sibling == current_idx || push!(neighbors, sibling)
             end
         end
         for neighbor_idx in neighbors
@@ -388,15 +388,16 @@ end
 
 Return the common per-unit-length stiffness `[N]` of the tether's
 segments. Errors if the segments are not uniform, since the spring
-inversion in `apply_tether_init_forces!` assumes a single stiffness.
+inversion in `apply_tether_init_forces!` assumes a single stiffnesys_state.
 """
 function tether_unit_stiffness(tether, segments)
-    ks = SimFloat[segments[si].unit_stiffness
-                  for si in tether.segment_idxs]
-    k = first(ks)
-    all(≈(k), ks) || error("Tether $(tether.name): requires " *
-        "uniform unit_stiffness across its segments, got $ks")
-    return k
+    stiffness_values = SimFloat[segments[seg_idx].unit_stiffness
+                                for seg_idx in tether.segment_idxs]
+    stiffness = first(stiffness_values)
+    all(≈(stiffness), stiffness_values) ||
+        error("Tether $(tether.name): requires uniform unit_stiffness " *
+              "across its segments, got $stiffness_values")
+    return stiffness
 end
 
 """
@@ -413,55 +414,55 @@ tether. For a multi-tether cluster, logs an `@info` when `prn`.
 """
 function apply_cluster_init_stretched_len!(
     cluster, points, segments, downstream, boundary; prn=true)
-    snaps = map(cluster) do t
-        anchor_idx, free_idx = tether_anchor_free(t, boundary)
+    snaps = map(cluster) do tether
+        anchor_idx, free_idx = tether_anchor_free(tether, boundary)
         anchor_pos = copy(points[anchor_idx].pos_w)
         free_pos = copy(points[free_idx].pos_w)
-        ordered = tether_ordered_point_idxs(t, segments)
-        seg_lens = SimFloat[segment_world_length(segments[si], points)
-                            for si in t.segment_idxs]
+        ordered = tether_ordered_point_idxs(tether, segments)
+        seg_lens = SimFloat[segment_world_length(segments[seg_idx], points)
+                            for seg_idx in tether.segment_idxs]
         if ordered[1] != anchor_idx
             reverse!(ordered)
             reverse!(seg_lens)
         end
         path_len = sum(seg_lens)
-        path_len > 0 || error("Tether $(t.name): current length is " *
+        path_len > 0 || error("Tether $(tether.name): current length is " *
             "zero, cannot scale to its stretched length")
-        (; t, free_idx, anchor_pos, free_pos, ordered, seg_lens, path_len)
+        (; tether, free_idx, anchor_pos, free_pos, ordered, seg_lens, path_len)
     end
 
-    deltas = [(s.t.init_stretched_len::SimFloat / s.path_len - 1) .*
-              (s.free_pos .- s.anchor_pos) for s in snaps]
+    deltas = [(snap.tether.init_stretched_len::SimFloat / snap.path_len - 1) .*
+              (snap.free_pos .- snap.anchor_pos) for snap in snaps]
     delta = sum(deltas) ./ length(deltas)
 
     if length(cluster) > 1 && prn
-        names = join((string(s.t.name) for s in snaps), ", ")
+        names = join((string(snap.tether.name) for snap in snaps), ", ")
         @info "Tethers ($names) feed one structure; placing it to the " *
               "mean stretched length and direction of all."
     end
     norm(delta) ≈ 0 && return
 
     moved = Set{Int64}()
-    for s in snaps
-        for idx in downstream[s.t.idx]
+    for snap in snaps
+        for idx in downstream[snap.tether.idx]
             idx in moved && continue
             push!(moved, idx)
             points[idx].pos_w .+= delta
         end
-        if !(s.free_idx in moved)
-            push!(moved, s.free_idx)
-            points[s.free_idx].pos_w .+= delta
+        if !(snap.free_idx in moved)
+            push!(moved, snap.free_idx)
+            points[snap.free_idx].pos_w .+= delta
         end
     end
 
-    for s in snaps
-        length(s.ordered) <= 2 && continue
-        line = (s.free_pos .+ delta) .- s.anchor_pos
+    for snap in snaps
+        length(snap.ordered) <= 2 && continue
+        line = (snap.free_pos .+ delta) .- snap.anchor_pos
         cum = 0.0
-        for k in 2:length(s.ordered)-1
-            cum += s.seg_lens[k-1]
-            points[s.ordered[k]].pos_w .=
-                s.anchor_pos .+ (cum / s.path_len) .* line
+        for k in 2:length(snap.ordered)-1
+            cum += snap.seg_lens[k-1]
+            points[snap.ordered[k]].pos_w .=
+                snap.anchor_pos .+ (cum / snap.path_len) .* line
         end
     end
 end
@@ -486,7 +487,8 @@ function apply_tether_init_stretched_lens!(sys_struct::SystemStructure;
                                            prn=true)
     (; points, segments, tethers, winches, wings) = sys_struct
 
-    specified = [t for t in tethers if !isnothing(t.init_stretched_len)]
+    specified = [tether for tether in tethers
+                 if !isnothing(tether.init_stretched_len)]
     isempty(specified) && return
 
     rigid_siblings = rigid_point_siblings(points, wings)
@@ -496,23 +498,25 @@ function apply_tether_init_stretched_lens!(sys_struct::SystemStructure;
         point.type == STATIC && push!(boundary, point.idx)
     end
 
-    anchor_free = Dict(t.idx => tether_anchor_free(t, boundary)
-                       for t in specified)
-    non_root = [t for t in specified if isnothing(anchor_free[t.idx][1])]
+    anchor_free = Dict(tether.idx => tether_anchor_free(tether, boundary)
+                       for tether in specified)
+    non_root = [tether for tether in specified
+                if isnothing(anchor_free[tether.idx][1])]
     if !isempty(non_root)
-        names = join((string(t.name) for t in non_root), ", ")
+        names = join((string(tether.name) for tether in non_root), ", ")
         error("tether length is only supported on tethers anchored at " *
               "a STATIC or winch point. Tether(s) ($names) have neither " *
               "endpoint anchored; their position rides the root tether.")
     end
 
-    downstream = Dict(t.idx => tether_downstream_idxs(
-                          t, segments, boundary, anchor_free[t.idx][2],
-                          anchor_free[t.idx][1], rigid_siblings)
-                      for t in specified)
-    reach = Dict(t.idx => union(
-        setdiff(Set{Int64}(tether_ordered_point_idxs(t, segments)), boundary),
-        downstream[t.idx]) for t in specified)
+    downstream = Dict(tether.idx => tether_downstream_idxs(
+                          tether, segments, boundary, anchor_free[tether.idx][2],
+                          anchor_free[tether.idx][1], rigid_siblings)
+                      for tether in specified)
+    reach = Dict(tether.idx => union(
+        setdiff(Set{Int64}(tether_ordered_point_idxs(tether, segments)),
+                boundary),
+        downstream[tether.idx]) for tether in specified)
 
     for cluster in group_tethers_by_overlap(specified, reach)
         apply_cluster_init_stretched_len!(cluster, points, segments,
@@ -536,8 +540,8 @@ if `stretch_frac ≤ 0`, if `force < 0`, if `force ≥
 unit_stiffness`, or if the segments have non-uniform `unit_stiffness`.
 """
 function init_unstretched_len(tether, segments)
-    stretched = sum(segments[si].len
-                    for si in tether.segment_idxs)
+    stretched = sum(segments[seg_idx].len
+                    for seg_idx in tether.segment_idxs)
     frac = tether.init_stretch_frac
     force = tether.init_tether_force
     if !isnothing(frac) && !isnothing(force)
@@ -554,11 +558,11 @@ function init_unstretched_len(tether, segments)
         "init_tether_force $force N is negative; " *
         "compression is not supported")
     force == 0 && return stretched
-    k = tether_unit_stiffness(tether, segments)
-    force < k || error("Tether $(tether.name): " *
-        "init_tether_force $force N ≥ unit_stiffness $k N; " *
+    stiffness = tether_unit_stiffness(tether, segments)
+    force < stiffness || error("Tether $(tether.name): " *
+        "init_tether_force $force N ≥ unit_stiffness $stiffness N; " *
         "no positive rest length achieves this force")
-    return stretched * (1 - force / k)
+    return stretched * (1 - force / stiffness)
 end
 
 """
@@ -640,8 +644,8 @@ function reinit!(sys_struct::SystemStructure, set::Settings;
         n = length(tether.segment_idxs)
         n == 0 && continue
         l0 = tether.len / n
-        for si in tether.segment_idxs
-            segments[si].l0 = l0
+        for seg_idx in tether.segment_idxs
+            segments[seg_idx].l0 = l0
         end
     end
 
@@ -749,9 +753,9 @@ function reinit!(sys_struct::SystemStructure, set::Settings;
     # Recalculate segment rest lengths from current positions if requested
     if ignore_l0
         for segment in segments
-            p1 = points[segment.point_idxs[1]]
-            p2 = points[segment.point_idxs[2]]
-            segment.l0 = norm(p2.pos_w - p1.pos_w)
+            point1 = points[segment.point_idxs[1]]
+            point2 = points[segment.point_idxs[2]]
+            segment.l0 = norm(point2.pos_w - point1.pos_w)
         end
     end
 
@@ -864,7 +868,7 @@ end
 # ==================== SYSSTATE INTEROP ==================== #
 
 """
-    update_from_sysstate!(sys::SystemStructure, ss::SysState)
+    update_from_sysstate!(sys::SystemStructure, sys_state::SysState)
 
 Update the dynamic state of a `SystemStructure` from a `SysState` snapshot.
 
@@ -878,18 +882,18 @@ and applying them to a `SystemStructure` for plotting with the Makie extension.
 
 # Arguments
 - `sys::SystemStructure`: The system structure to update (must already exist with correct topology).
-- `ss::SysState`: The state snapshot to copy from.
+- `sys_state::SysState`: The state snapshot to copy from.
 
 # Example
 ```julia
 # Load a system log
-lg = load_log(...)
+sim_log = load_log(...)
 
 # Create a SystemStructure with the same topology
 sys = SystemStructure(se(), "ram")
 
 # Update from a specific time step
-update_from_sysstate!(sys, lg.syslog[100])
+update_from_sysstate!(sys, sim_log.syslog[100])
 
 # Plot the system at that time step
 plot(sys)
@@ -901,7 +905,7 @@ plot(sys)
 - Aerodynamic and force fields are set to `NaN` and will not be plotted.
 - The number of points in `sys` must match the parametric type `P` of `SysState{P}`.
 """
-function update_from_sysstate!(sys::SystemStructure, ss::SysState{P}) where P
+function update_from_sysstate!(sys::SystemStructure, sys_state::SysState{P}) where P
     (; points, groups, tethers, winches, wings) = sys
 
     # Total slots: structural points + panel corners + wings.
@@ -926,9 +930,9 @@ function update_from_sysstate!(sys::SystemStructure, ss::SysState{P}) where P
 
     # Update point positions (X, Y, Z from SysState)
     for point in points
-        point.pos_w[1] = ss.X[point.idx]
-        point.pos_w[2] = ss.Y[point.idx]
-        point.pos_w[3] = ss.Z[point.idx]
+        point.pos_w[1] = sys_state.X[point.idx]
+        point.pos_w[2] = sys_state.Y[point.idx]
+        point.pos_w[3] = sys_state.Z[point.idx]
         # Set velocity to zero (not available in basic SysState)
         point.vel_w .= 0.0
         # Set forces to NaN (not available in SysState)
@@ -940,27 +944,27 @@ function update_from_sysstate!(sys::SystemStructure, ss::SysState{P}) where P
         wing = wings[1]
 
         # Copy orientation quaternion
-        wing.Q_b_to_w .= ss.orient
+        wing.Q_b_to_w .= sys_state.orient
 
         # Copy spherical coordinates
-        wing.elevation = Float64(ss.elevation)
-        wing.azimuth = Float64(ss.azimuth)
-        wing.heading = Float64(ss.heading)
+        wing.elevation = Float64(sys_state.elevation)
+        wing.azimuth = Float64(sys_state.azimuth)
+        wing.heading = Float64(sys_state.heading)
 
         if has_wing_slots
             wing_slot = n_points + n_panel_corners + wing.idx
-            wing.pos_w[1] = ss.X[wing_slot]
-            wing.pos_w[2] = ss.Y[wing_slot]
-            wing.pos_w[3] = ss.Z[wing_slot]
+            wing.pos_w[1] = sys_state.X[wing_slot]
+            wing.pos_w[2] = sys_state.Y[wing_slot]
+            wing.pos_w[3] = sys_state.Z[wing_slot]
         else
-            wing.pos_w .= [mean(ss.X), mean(ss.Y), mean(ss.Z)]
+            wing.pos_w .= [mean(sys_state.X), mean(sys_state.Y), mean(sys_state.Z)]
         end
 
         # Copy velocity if available in vel_kite
-        wing.vel_w .= ss.vel_kite
+        wing.vel_w .= sys_state.vel_kite
 
         # Set angular velocity to NaN (turn_rates in SysState, but need conversion)
-        wing.ω_b .= ss.turn_rates
+        wing.ω_b .= sys_state.turn_rates
 
         # Set aerodynamic quantities to NaN (to prevent plotting)
         wing.aero_force_b .= NaN
@@ -968,11 +972,11 @@ function update_from_sysstate!(sys::SystemStructure, ss::SysState{P}) where P
         wing.tether_force .= NaN
         wing.tether_moment .= NaN
         wing.va_b .= NaN
-        wing.v_wind .= ss.v_wind_kite
-        wing.aoa = Float64(ss.AoA)
-        wing.course = Float64(ss.course)
+        wing.v_wind .= sys_state.v_wind_kite
+        wing.aoa = Float64(sys_state.AoA)
+        wing.course = Float64(sys_state.course)
         wing.acc_w .= 0.0
-        wing.turn_rate .= ss.turn_rates
+        wing.turn_rate .= sys_state.turn_rates
         wing.turn_acc .= 0.0
     end
 
@@ -980,7 +984,7 @@ function update_from_sysstate!(sys::SystemStructure, ss::SysState{P}) where P
     n_groups = min(length(groups), 4)  # SysState stores up to 4 twist angles
     for i in 1:n_groups
         if i <= length(groups)
-            groups[i].twist = Float64(ss.twist_angles[i])
+            groups[i].twist = Float64(sys_state.twist_angles[i])
             groups[i].twist_ω = 0.0  # Not available in SysState
             # Set forces/moments to NaN
             groups[i].tether_force = NaN
@@ -997,8 +1001,8 @@ function update_from_sysstate!(sys::SystemStructure, ss::SysState{P}) where P
         isempty(vsm.non_deformed_sections) && continue
         theta = zeros(Float64, vsm.n_unrefined_sections)
         for g_idx in wing.group_idxs
-            for u in groups[g_idx].unrefined_section_idxs
-                theta[u] = groups[g_idx].twist
+            for section_idx in groups[g_idx].unrefined_section_idxs
+                theta[section_idx] = groups[g_idx].twist
             end
         end
         VortexStepMethod.unrefined_deform!(vsm, theta)
@@ -1006,9 +1010,9 @@ function update_from_sysstate!(sys::SystemStructure, ss::SysState{P}) where P
     end
 
     # Update tether lengths from SysState (per-tether)
-    for (ti, tether) in enumerate(tethers)
-        ti > 4 && break
-        tether.len = Float64(ss.l_tether[ti])
+    for (tether_idx, tether) in enumerate(tethers)
+        tether_idx > 4 && break
+        tether.len = Float64(sys_state.l_tether[tether_idx])
     end
 
     # Update winch state from SysState (per-winch)
@@ -1017,8 +1021,8 @@ function update_from_sysstate!(sys::SystemStructure, ss::SysState{P}) where P
         winches[i].force .= NaN
         winches[i].friction = NaN
         winches[i].acc = 0.0
-        winches[i].vel = Float64(ss.v_reelout[i])
-        winches[i].set_value = Float64(ss.set_torque[i])
+        winches[i].vel = Float64(sys_state.v_reelout[i])
+        winches[i].set_value = Float64(sys_state.set_torque[i])
     end
 
     corner_idx = n_points
@@ -1033,7 +1037,7 @@ function update_from_sysstate!(sys::SystemStructure, ss::SysState{P}) where P
         for panel in wing.vsm_aero.panels
             for j in 1:4
                 corner_idx += 1
-                corner_w = [ss.X[corner_idx], ss.Y[corner_idx], ss.Z[corner_idx]]
+                corner_w = [sys_state.X[corner_idx], sys_state.Y[corner_idx], sys_state.Z[corner_idx]]
                 panel.corner_points[:, j] .= R_w_to_b * (corner_w - wing.pos_w)
             end
         end
@@ -1041,7 +1045,7 @@ function update_from_sysstate!(sys::SystemStructure, ss::SysState{P}) where P
 
     # Update global wind vector (only if wind_vec mode is active)
     if sys.set.use_wind_vec
-        sys.set.wind_vec = MVec3(ss.v_wind_gnd)
+        sys.set.wind_vec = MVec3(sys_state.v_wind_gnd)
     end
 
     # Calculate segment lengths and forces from current positions and velocities
@@ -1202,7 +1206,7 @@ function segment_stretch_stats(sys::SystemStructure)
         return (0.0, 0.0, 0)
     end
 
-    stretches = [s[2] for s in stretch_data]
+    stretches = [entry[2] for entry in stretch_data]
     max_stretch = maximum(stretches)
     mean_stretch = sum(stretches) / length(stretches)
     max_idx = stretch_data[argmax(stretches)][1]

--- a/src/system_structure/wing.jl
+++ b/src/system_structure/wing.jl
@@ -184,8 +184,8 @@ function WeightedRefPoints(refs::AbstractVector)
         "WeightedRefPoints requires at least one " *
         "reference point, got empty vector")
     if refs[1] isa Tuple
-        names = NameRef[_to_name_ref(t[1]) for t in refs]
-        weights = Float64[Float64(t[2]) for t in refs]
+        names = NameRef[_to_name_ref(entry[1]) for entry in refs]
+        weights = Float64[Float64(entry[2]) for entry in refs]
         _validate_weights!(weights)
         return WeightedRefPoints(names, Int64[], weights)
     end
@@ -371,10 +371,10 @@ function BaseWing(name, groups::AbstractVector, R_b_to_c::AbstractMatrix,
         AERO_LINEARIZED : AERO_DIRECT)
     aero_model = resolve_aero_model(aero_mode, aero_model)
     # Convert groups to NameRef vector
-    group_refs = Vector{NameRef}([_to_name_ref(g) for g in groups])
+    group_refs = Vector{NameRef}([_to_name_ref(group) for group in groups])
     # Handle nothing - default to transform 1
-    tf = isnothing(transform) ? 1 : transform
-    transform_ref = _to_name_ref(tf)
+    transform_value = isnothing(transform) ? 1 : transform
+    transform_ref = _to_name_ref(transform_value)
 
     # idx, group_idxs, transform_idx are placeholders - resolved by SystemStructure
     return BaseWing(0, name,
@@ -454,10 +454,10 @@ function create_vsm_wing(set::Settings, vsm_set::VortexStepMethod.VSMSettings; p
     # Fallback: load from aero_geometry.yaml using provided vsm_set
     prn && @info "Using provided VSMSettings for wing creation"
     # Resolve relative geometry_file paths against data dir
-    for ws in vsm_set.wings
-        gf = ws.geometry_file
-        if !isempty(gf) && !isabspath(gf)
-            ws.geometry_file = joinpath(model_dir, basename(gf))
+    for wing_settings in vsm_set.wings
+        geometry_file = wing_settings.geometry_file
+        if !isempty(geometry_file) && !isabspath(geometry_file)
+            wing_settings.geometry_file = joinpath(model_dir, basename(geometry_file))
         end
     end
     return VortexStepMethod.Wing(vsm_set; sort_sections)
@@ -580,17 +580,18 @@ function VSMWing(name, set::Settings,
     # as group count proxy; resized in SystemStructure
     # after groups are resolved.
     if dynamics_type == PARTICLE_DYNAMICS
-        nx = 0
-        ny = 0
+        num_aero_outputs = 0
+        num_aero_inputs = 0
     else
         n_groups_est = vsm_wing.n_unrefined_sections
-        nx = 6 + n_groups_est
-        ny = 5 + n_groups_est
+        num_aero_outputs = 6 + n_groups_est
+        num_aero_inputs = 5 + n_groups_est
     end
 
     return VSMWing(base, vsm_aero, vsm_wing, vsm_solver,
-                   zeros(SimFloat, ny), zeros(SimFloat, nx),
-                   zeros(SimFloat, nx, ny),
+                   zeros(SimFloat, num_aero_inputs),
+                   zeros(SimFloat, num_aero_outputs),
+                   zeros(SimFloat, num_aero_outputs, num_aero_inputs),
                    point_to_vsm_point, wing_segments,
                    z_ref, y_ref,
                    origin_rp,
@@ -629,11 +630,12 @@ function VSMWing(name, vsm_aero, vsm_wing, vsm_solver,
                     inertia_vec; transform)
     # Placeholder aero arrays — resized by SystemStructure
     n_groups_est = vsm_wing.n_unrefined_sections
-    nx = 6 + n_groups_est
-    ny = 5 + n_groups_est
+    num_aero_outputs = 6 + n_groups_est
+    num_aero_inputs = 5 + n_groups_est
     return VSMWing(base, vsm_aero, vsm_wing, vsm_solver,
-        zeros(SimFloat, ny), zeros(SimFloat, nx),
-        zeros(SimFloat, nx, ny),
+        zeros(SimFloat, num_aero_inputs),
+        zeros(SimFloat, num_aero_outputs),
+        zeros(SimFloat, num_aero_outputs, num_aero_inputs),
         nothing, nothing,
         nothing, nothing,  # z/y_ref_points
         nothing,           # origin
@@ -847,9 +849,9 @@ Compute current AoA [deg] from body-frame apparent wind and
 twist. Requires `va_b` to be up to date.
 """
 function plate_alpha(wing::PlateWing, surf::PlateSurface)
-    tw = surf.twist
-    ct, st = cos(tw), sin(tw)
-    x_tw = ct * surf.x_airf + st * (surf.y_airf × surf.x_airf)
+    twist_angle = surf.twist
+    cos_twist, sin_twist = cos(twist_angle), sin(twist_angle)
+    x_tw = cos_twist * surf.x_airf + sin_twist * (surf.y_airf × surf.x_airf)
     z_tw = x_tw × surf.y_airf
     v_tan = wing.va_b ⋅ x_tw
     v_norm = wing.va_b ⋅ z_tw

--- a/src/system_structure/wing.jl
+++ b/src/system_structure/wing.jl
@@ -305,12 +305,6 @@ end
 _to_name_ref(x::Integer) = Int(x)
 _to_name_ref(x) = Symbol(x)
 
-"""
-    default_aero_model_for(aero_mode) -> Function
-
-Map a built-in `AeroMode` to its default aero component builder.
-`AERO_CUSTOM` has no default and requires an explicit `aero_model`.
-"""
 function default_aero_model_for(aero_mode::AeroMode)
     aero_mode == AERO_NONE       && return default_aero_none
     aero_mode == AERO_DIRECT     && return default_aero_direct
@@ -320,13 +314,6 @@ function default_aero_model_for(aero_mode::AeroMode)
           "AERO_CUSTOM requires an explicit `aero_model` builder.")
 end
 
-"""
-    resolve_aero_model(aero_mode, aero_model) -> Function
-
-Resolve the wing's aero component builder. A built-in `aero_mode`
-selects its default builder and forbids a user-supplied one; an
-explicit `aero_model` requires `aero_mode = AERO_CUSTOM`.
-"""
 function resolve_aero_model(aero_mode::AeroMode,
                             aero_model::Union{Nothing,Function})
     if aero_mode == AERO_CUSTOM

--- a/src/system_structure/wing.jl
+++ b/src/system_structure/wing.jl
@@ -66,6 +66,7 @@ mutable struct BaseWing <: AbstractWing
     const inertia_principal::KVec3
     const dynamics_type::WingType
     aero_mode::AeroMode
+    aero_model::Function
 
     # Principal frame ODE state (RIGID_DYNAMICS dynamics)
     const com_w::KVec3                  # COM position in world frame
@@ -305,6 +306,42 @@ _to_name_ref(x::Integer) = Int(x)
 _to_name_ref(x) = Symbol(x)
 
 """
+    default_aero_model_for(aero_mode) -> Function
+
+Map a built-in `AeroMode` to its default aero component builder.
+`AERO_CUSTOM` has no default and requires an explicit `aero_model`.
+"""
+function default_aero_model_for(aero_mode::AeroMode)
+    aero_mode == AERO_NONE       && return default_aero_none
+    aero_mode == AERO_DIRECT     && return default_aero_direct
+    aero_mode == AERO_LINEARIZED && return default_aero_linearized
+    aero_mode == AERO_PLATE      && return default_aero_plate
+    error("aero_mode = $aero_mode has no default `aero_model`; " *
+          "AERO_CUSTOM requires an explicit `aero_model` builder.")
+end
+
+"""
+    resolve_aero_model(aero_mode, aero_model) -> Function
+
+Resolve the wing's aero component builder. A built-in `aero_mode`
+selects its default builder and forbids a user-supplied one; an
+explicit `aero_model` requires `aero_mode = AERO_CUSTOM`.
+"""
+function resolve_aero_model(aero_mode::AeroMode,
+                            aero_model::Union{Nothing,Function})
+    if aero_mode == AERO_CUSTOM
+        isnothing(aero_model) && error(
+            "aero_mode = AERO_CUSTOM requires an explicit " *
+            "`aero_model` builder.")
+        return aero_model
+    end
+    isnothing(aero_model) || error(
+        "Providing a custom `aero_model` requires " *
+        "`aero_mode = AERO_CUSTOM` (got aero_mode = $aero_mode).")
+    return default_aero_model_for(aero_mode)
+end
+
+"""
     BaseWing(name, groups, R_b_to_c, pos_cad, inertia_principal; transform=nothing, y_damping=150.0, dynamics_type=RIGID_DYNAMICS)
 
 Constructs a `BaseWing` object representing a rigid body reference frame.
@@ -331,6 +368,7 @@ function BaseWing(name, groups::AbstractVector, R_b_to_c::AbstractMatrix,
                   angular_damping=0.0,
                   dynamics_type::Union{Nothing,WingType}=nothing,
                   aero_mode::Union{Nothing,AeroMode}=nothing,
+                  aero_model::Union{Nothing,Function}=nothing,
                   wing_type::Union{Nothing,WingType}=nothing)
     # Handle deprecated wing_type keyword
     if !isnothing(wing_type)
@@ -344,6 +382,7 @@ function BaseWing(name, groups::AbstractVector, R_b_to_c::AbstractMatrix,
     isnothing(dynamics_type) && (dynamics_type = RIGID_DYNAMICS)
     isnothing(aero_mode) && (aero_mode = dynamics_type == RIGID_DYNAMICS ?
         AERO_LINEARIZED : AERO_DIRECT)
+    aero_model = resolve_aero_model(aero_mode, aero_model)
     # Convert groups to NameRef vector
     group_refs = Vector{NameRef}([_to_name_ref(g) for g in groups])
     # Handle nothing - default to transform 1
@@ -361,7 +400,7 @@ function BaseWing(name, groups::AbstractVector, R_b_to_c::AbstractMatrix,
         Matrix{SimFloat}(I, 3, 3),         # R_b_to_p placeholder
         pos_cad, zeros(KVec3),  # com_offset_b placeholder
         inertia_principal, dynamics_type,
-        aero_mode,
+        aero_mode, aero_model,
         # Principal frame ODE state
         zeros(KVec3), zeros(KVec3),  # com_w, com_vel
         zeros(4), zeros(KVec3),      # Q_p_to_w, ω_p
@@ -480,6 +519,7 @@ function VSMWing(name, set::Settings,
                  inertia_diag=nothing,
                  dynamics_type::Union{Nothing,WingType}=nothing,
                  aero_mode::Union{Nothing,AeroMode}=nothing,
+                 aero_model::Union{Nothing,Function}=nothing,
                  wing_type::Union{Nothing,WingType}=nothing,
                  point_to_vsm_point::Union{Nothing, Dict{Int64, Tuple{Int64, Symbol}}}=nothing,
                  wing_segments::Union{Nothing, Vector{Tuple{Int64, Int64}}}=nothing,
@@ -545,7 +585,8 @@ function VSMWing(name, set::Settings,
 
     base = BaseWing(name, groups, R_b_to_c, pos_cad,
                     inertia_vec; transform, y_damping,
-                    angular_damping, dynamics_type, aero_mode)
+                    angular_damping, dynamics_type, aero_mode,
+                    aero_model)
 
     # Size aero state vectors based on wing type
     # For RIGID_DYNAMICS: placeholder sizes using n_unrefined

--- a/src/vsm_refine.jl
+++ b/src/vsm_refine.jl
@@ -138,12 +138,12 @@ function match_aero_sections_to_structure!(
     if has_groups
         n_struct_sections = length(wing_group_idxs)
         for g_idx in wing_group_idxs
-            g = groups[g_idx]
-            length(g.point_idxs) == 2 || error(
+            group = groups[g_idx]
+            length(group.point_idxs) == 2 || error(
                 "PARTICLE_DYNAMICS wing $(wing.idx): group " *
-                "$(g.name) must have exactly 2 " *
+                "$(group.name) must have exactly 2 " *
                 "points (LE/TE pair), got " *
-                "$(length(g.point_idxs))")
+                "$(length(group.point_idxs))")
         end
     else
         n_points = length(wing_points)
@@ -342,32 +342,33 @@ function compute_aerostruc_loads(panel, F_panel::SVector{3}, M_panel::SVector{3}
     # Relative positions
     r_le_rel = r_le_mid - r_ac
     r_te_rel = r_te_mid - r_ac
-    d = r_le_rel - r_te_rel  # chord direction (LE→TE)
-    d_norm_sq = dot(d, d)
-    if d_norm_sq < 1e-12
+    chord_dir = r_le_rel - r_te_rel  # chord direction (LE→TE)
+    chord_norm_sq = dot(chord_dir, chord_dir)
+    if chord_norm_sq < 1e-12
         # Degenerate chord: just split equally and spanwise-preserve the torque
         F_le = 0.5 * F_panel
         F_te = 0.5 * F_panel
     else
         # Minimum-norm split that preserves moment about r_ref
-        w_le = clamp(-dot(r_te_rel, d) / d_norm_sq, 0.0, 1.0)
+        w_le = clamp(-dot(r_te_rel, chord_dir) / chord_norm_sq, 0.0, 1.0)
         r_weighted = w_le * r_le_rel + (1 - w_le) * r_te_rel
         M_cp = M_panel - cross(r_ac - r_ref, F_panel)
         M_target = M_cp - cross(r_weighted, F_panel)
-        ΔF = cross(M_target, d) / d_norm_sq
+        ΔF = cross(M_target, chord_dir) / chord_norm_sq
         F_le = w_le * F_panel + ΔF
         F_te = (1 - w_le) * F_panel - ΔF
     end
 
     # Spanwise split preserving moment about r_ref
     span_split = function (F::SVector{3}, r_mid::SVector{3}, r_left::SVector{3}, r_right::SVector{3})
-        a = cross(r_left - r_ref, F)
-        b = cross(r_right - r_ref, F)
+        left_moment = cross(r_left - r_ref, F)
+        right_moment = cross(r_right - r_ref, F)
         m_target = cross(r_mid - r_ref, F)
-        ab = a - b
-        denom = dot(ab, ab)
-        w = denom < 1e-14 ? 0.5 : clamp(dot(ab, m_target - b) / denom, 0.0, 1.0)
-        return (w * F, (1 - w) * F)
+        moment_diff = left_moment - right_moment
+        denom = dot(moment_diff, moment_diff)
+        split_weight = denom < 1e-14 ? 0.5 :
+            clamp(dot(moment_diff, m_target - right_moment) / denom, 0.0, 1.0)
+        return (split_weight * F, (1 - split_weight) * F)
     end
 
     F_le_left, F_le_right = span_split(F_le, r_le_mid, nodes[1], nodes[2])
@@ -432,9 +433,9 @@ function distribute_panel_forces_to_points!(wing::VSMWing, points::AbstractVecto
     # Determine offset of this wing's panels in the solver arrays
     start_idx = 1
     if hasproperty(wing.vsm_solver, :body_aero)
-        for w in wing.vsm_solver.body_aero.wings
-            w === wing && break
-            start_idx += length(w.vsm_aero.panels)
+        for other_wing in wing.vsm_solver.body_aero.wings
+            other_wing === wing && break
+            start_idx += length(other_wing.vsm_aero.panels)
         end
     end
 
@@ -444,8 +445,8 @@ function distribute_panel_forces_to_points!(wing::VSMWing, points::AbstractVecto
         panel_idx = start_idx + local_panel_idx - 1
         panel = panels[local_panel_idx]
         scale = 1.0 + (isfinite(wing.aero_scale_chord) ? wing.aero_scale_chord : AERO_SCALE_CHORD)
-        Fp = scale .* SVector{3}(f_body[:, panel_idx])
-        Mp = scale .* SVector{3}(m_body[:, panel_idx])
+        panel_force = scale .* SVector{3}(f_body[:, panel_idx])
+        panel_moment = scale .* SVector{3}(m_body[:, panel_idx])
 
         section_idx = panel_to_section[local_panel_idx]
 
@@ -454,7 +455,8 @@ function distribute_panel_forces_to_points!(wing::VSMWing, points::AbstractVecto
         haskey(vsm_point_to_struct, le_key) || continue
         haskey(vsm_point_to_struct, te_key) || continue
 
-        F_le_left, F_le_right, F_te_right, F_te_left, _ = compute_aerostruc_loads(panel, Fp, Mp)
+        F_le_left, F_le_right, F_te_right, F_te_left, _ =
+            compute_aerostruc_loads(panel, panel_force, panel_moment)
         F_le = F_le_left + F_le_right
         F_te = F_te_left + F_te_right
 

--- a/src/yaml_loader.jl
+++ b/src/yaml_loader.jl
@@ -39,8 +39,8 @@ convert_to_type(::Type{T}, value) where T = T(value)
 # Special handling for Tuple types
 function convert_to_type(
         ::Type{Tuple{T,T}}, value) where T
-    vec = Vector{Int}(value)
-    return (T(vec[1]), T(vec[2]))
+    values = Vector{Int}(value)
+    return (T(values[1]), T(values[2]))
 end
 
 """
@@ -61,12 +61,12 @@ function resolve_references(row::NamedTuple, property_tables::Dict{String, Dict{
                 if haskey(lookup_dict, value)
                     # Found! Merge these properties (current row takes precedence)
                     ref_props = lookup_dict[value]
-                    for (k, v) in pairs(ref_props)
+                    for (key, field_value) in pairs(ref_props)
                         # Skip 'name' — it identifies the referenced
                         # item, not a property to inherit.
-                        k === :name && continue
-                        if !haskey(resolved, k) || resolved[k] === nothing
-                            resolved[k] = v
+                        key === :name && continue
+                        if !haskey(resolved, key) || resolved[key] === nothing
+                            resolved[key] = field_value
                         end
                     end
                     break
@@ -94,10 +94,10 @@ function calculate_derived_properties!(props::Dict{Symbol, Any})
                           props[:unit_stiffness] isa String
 
         if need_calculation
-            d_m = Float64(props[:diameter_mm]) / 1000.0  # mm to m
-            A = π * (d_m / 2)^2
-            E = Float64(props[:youngs_modulus])
-            props[:unit_stiffness] = E * A
+            diameter_m = Float64(props[:diameter_mm]) / 1000.0  # mm to m
+            area = π * (diameter_m / 2)^2
+            youngs_modulus = Float64(props[:youngs_modulus])
+            props[:unit_stiffness] = youngs_modulus * area
         end
     end
 
@@ -121,10 +121,10 @@ function calculate_derived_properties!(props::Dict{Symbol, Any})
     end
 end
 
-function parse_table(tbl)::Vector{NamedTuple}
-    haskey(tbl, "data") || throw(ArgumentError("table is missing `data`"))
+function parse_table(table)::Vector{NamedTuple}
+    haskey(table, "data") || throw(ArgumentError("table is missing `data`"))
 
-    rows = tbl["data"]
+    rows = table["data"]
     (isnothing(rows) || isempty(rows)) && return NamedTuple[]
 
     # Check format: if first row is a Dict,
@@ -136,17 +136,17 @@ function parse_table(tbl)::Vector{NamedTuple}
         # Convert each dict to a NamedTuple
         out = NamedTuple[]
         for row in rows
-            nt = NamedTuple{Tuple(Symbol.(keys(row)))}(
+            named_row = NamedTuple{Tuple(Symbol.(keys(row)))}(
                 Tuple(values(row)))
-            push!(out, nt)
+            push!(out, named_row)
         end
         return out
     else
         # Array format: requires headers
-        haskey(tbl, "headers") ||
+        haskey(table, "headers") ||
             throw(ArgumentError(
                 "table with array rows requires `headers`"))
-        headers = String.(tbl["headers"])
+        headers = String.(table["headers"])
 
         out = NamedTuple[]
         for (k, row) in enumerate(rows)
@@ -165,8 +165,8 @@ function parse_table(tbl)::Vector{NamedTuple}
                       "values, expected $(length(headers))."
                 continue
             end
-            nt = NamedTuple{Tuple(Symbol.(headers))}(Tuple(row))
-            push!(out, nt)
+            named_row = NamedTuple{Tuple(Symbol.(headers))}(Tuple(row))
+            push!(out, named_row)
         end
         return out
     end
@@ -267,55 +267,55 @@ function call_yaml_constructor(
     end
 end
 
-function parse_dynamics_type(s::String)
-    s_upper = uppercase(s)
-    s_upper == "STATIC" && return STATIC
-    s_upper == "DYNAMIC" && return DYNAMIC
-    s_upper == "WING" && return WING
-    s_upper == "QUASI_STATIC" && return QUASI_STATIC
-    error("Unknown DynamicsType: $s")
+function parse_dynamics_type(text::String)
+    text_upper = uppercase(text)
+    text_upper == "STATIC" && return STATIC
+    text_upper == "DYNAMIC" && return DYNAMIC
+    text_upper == "WING" && return WING
+    text_upper == "QUASI_STATIC" && return QUASI_STATIC
+    error("Unknown DynamicsType: $text")
 end
 
-function parse_segment_type(s::String)
-    s_upper = uppercase(s)
-    s_upper == "POWER_LINE" && return POWER_LINE
-    s_upper == "STEERING_LINE" && return STEERING_LINE
-    s_upper == "BRIDLE" && return BRIDLE
-    error("Unknown SegmentType: $s")
+function parse_segment_type(text::String)
+    text_upper = uppercase(text)
+    text_upper == "POWER_LINE" && return POWER_LINE
+    text_upper == "STEERING_LINE" && return STEERING_LINE
+    text_upper == "BRIDLE" && return BRIDLE
+    error("Unknown SegmentType: $text")
 end
 
-function parse_wing_type(s::String)
-    s_upper = uppercase(s)
-    s_upper == "PARTICLE_DYNAMICS" && return PARTICLE_DYNAMICS
-    s_upper == "RIGID_DYNAMICS" && return RIGID_DYNAMICS
-    if s_upper == "REFINE"
-        @warn "WingType \"$s\" is deprecated; use \"PARTICLE_DYNAMICS\" instead."
+function parse_wing_type(text::String)
+    text_upper = uppercase(text)
+    text_upper == "PARTICLE_DYNAMICS" && return PARTICLE_DYNAMICS
+    text_upper == "RIGID_DYNAMICS" && return RIGID_DYNAMICS
+    if text_upper == "REFINE"
+        @warn "WingType \"$text\" is deprecated; use \"PARTICLE_DYNAMICS\" instead."
         return PARTICLE_DYNAMICS
     end
-    if s_upper == "QUATERNION"
-        @warn "WingType \"$s\" is deprecated; use \"RIGID_DYNAMICS\" instead."
+    if text_upper == "QUATERNION"
+        @warn "WingType \"$text\" is deprecated; use \"RIGID_DYNAMICS\" instead."
         return RIGID_DYNAMICS
     end
-    error("Unknown WingType: $s")
+    error("Unknown WingType: $text")
 end
 
-function parse_aero_mode(s::String)
-    s_upper = uppercase(s)
-    s_upper == "AERO_NONE" && return AERO_NONE
-    s_upper == "AERO_DIRECT" && return AERO_DIRECT
-    s_upper == "AERO_LINEARIZED" && return AERO_LINEARIZED
-    s_upper == "AERO_PLATE" && return AERO_PLATE
-    error("Unknown AeroMode: $s")
+function parse_aero_mode(text::String)
+    text_upper = uppercase(text)
+    text_upper == "AERO_NONE" && return AERO_NONE
+    text_upper == "AERO_DIRECT" && return AERO_DIRECT
+    text_upper == "AERO_LINEARIZED" && return AERO_LINEARIZED
+    text_upper == "AERO_PLATE" && return AERO_PLATE
+    error("Unknown AeroMode: $text")
 end
 
 """
-    _load_plate_wing(row, idx, data, set, wt, am,
+    _load_plate_wing(row, idx, data, set, wing_type, aero_mode,
                      yaml_to_ref, yaml_parse_ref_points)
 
 Load a PlateWing from YAML wing row + surfaces block.
 CL/CD interpolations are created from Settings polar data.
 """
-function _load_plate_wing(row, idx, data, set, wt, am,
+function _load_plate_wing(row, idx, data, set, wing_type, aero_mode,
                           yaml_to_ref, yaml_parse_ref_points,
                           yaml_parse_origin)
     name = if haskey(row, :name) && !isnothing(row.name)
@@ -360,24 +360,24 @@ function _load_plate_wing(row, idx, data, set, wt, am,
        haskey(data["surfaces"], "data") &&
        data["surfaces"]["data"] !== nothing
         surf_rows = parse_table(data["surfaces"])
-        for (si, sr) in enumerate(surf_rows)
-            sname = haskey(sr, :name) && !isnothing(sr.name) ?
-                Symbol(sr.name) : nothing
-            x_airf = KVec3(sr.x_airf...)
-            y_airf = KVec3(sr.y_airf...)
-            area = float(sr.area)
-            point = yaml_to_ref(sr.point_idx)
-            twist = hasfield(typeof(sr), :twist) &&
-                !isnothing(sr.twist) ?
-                float(sr.twist) : 0.0
+        for (si, surf_row) in enumerate(surf_rows)
+            surf_name = haskey(surf_row, :name) && !isnothing(surf_row.name) ?
+                Symbol(surf_row.name) : nothing
+            x_airf = KVec3(surf_row.x_airf...)
+            y_airf = KVec3(surf_row.y_airf...)
+            area = float(surf_row.area)
+            point = yaml_to_ref(surf_row.point_idx)
+            twist = hasfield(typeof(surf_row), :twist) &&
+                !isnothing(surf_row.twist) ?
+                float(surf_row.twist) : 0.0
             push!(surfaces, PlateSurface(
-                sname, x_airf, y_airf, area, point;
+                surf_name, x_airf, y_airf, area, point;
                 twist))
         end
     end
 
     PlateWing(name, surfaces, cl_interp, cd_interp;
-              dynamics_type=wt, transform, y_damping,
+              dynamics_type=wing_type, transform, y_damping,
               drag_corr, cmq, smc, cord_length,
               z_ref_points=z_ref, y_ref_points=y_ref,
               origin)
@@ -458,21 +458,21 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
     #   7             → Int
     #   [a, b]        → equal-weight average
     #   [[a, w], ...] → explicit weights as (name, weight) tuples
-    yaml_convert_ref = function (v)
-        if v isa Vector && !isempty(v) && v[1] isa Vector
-            return map(v) do x
-                if !(x isa Vector) || length(x) != 2
-                    throw(ArgumentError("Invalid weighted reference point entry $(repr(x)); expected format [[id, weight], ...]"))
+    yaml_convert_ref = function (value)
+        if value isa Vector && !isempty(value) && value[1] isa Vector
+            return map(value) do entry
+                if !(entry isa Vector) || length(entry) != 2
+                    throw(ArgumentError("Invalid weighted reference point entry $(repr(entry)); expected format [[id, weight], ...]"))
                 end
-                if !(x[2] isa Number)
-                    throw(ArgumentError("Invalid weighted reference point weight $(repr(x[2])) in entry $(repr(x)); expected format [[id, weight], ...] with numeric weight"))
+                if !(entry[2] isa Number)
+                    throw(ArgumentError("Invalid weighted reference point weight $(repr(entry[2])) in entry $(repr(entry)); expected format [[id, weight], ...] with numeric weight"))
                 end
-                (yaml_to_ref(x[1]), Float64(x[2]))
+                (yaml_to_ref(entry[1]), Float64(entry[2]))
             end
-        elseif v isa Vector
-            return [yaml_to_ref(x) for x in v]
+        elseif value isa Vector
+            return [yaml_to_ref(entry) for entry in value]
         else
-            return yaml_to_ref(v)
+            return yaml_to_ref(value)
         end
     end
 
@@ -487,9 +487,9 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
             throw(ArgumentError("ref_points must have 2 elements"))
         end
 
-        p1 = yaml_convert_ref(val[1])
-        p2 = yaml_convert_ref(val[2])
-        return (p1, p2)
+        point_1 = yaml_convert_ref(val[1])
+        point_2 = yaml_convert_ref(val[2])
+        return (point_1, point_2)
     end
 
     # Parse a single weighted-ref field (e.g. origin_idx).
@@ -515,14 +515,14 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                  :body_frame_damping, :world_frame_damping,
                  :area, :drag_coeff];
                 mappings=Dict(
-                    :pos_cad => r -> KVec3(r.pos_cad...),
-                    :type => r -> parse_dynamics_type(String(r.type)),
-                    :name => r -> haskey(r, :name) && !isnothing(r.name) ? Symbol(r.name) : i,
+                    :pos_cad => row -> KVec3(row.pos_cad...),
+                    :type => row -> parse_dynamics_type(String(row.type)),
+                    :name => row -> haskey(row, :name) && !isnothing(row.name) ? Symbol(row.name) : i,
                     # Pass raw references - constructor handles defaults
-                    :wing => r -> haskey(r, :wing_idx) ? yaml_to_ref(r.wing_idx) : nothing,
-                    :transform => r -> haskey(r, :transform_idx) ? yaml_to_ref(r.transform_idx) : nothing,
-                    :body_frame_damping => r -> haskey(r, :body_frame_damping) ? r.body_frame_damping : nothing,
-                    :world_frame_damping => r -> haskey(r, :world_frame_damping) ? r.world_frame_damping : nothing
+                    :wing => row -> haskey(row, :wing_idx) ? yaml_to_ref(row.wing_idx) : nothing,
+                    :transform => row -> haskey(row, :transform_idx) ? yaml_to_ref(row.transform_idx) : nothing,
+                    :body_frame_damping => row -> haskey(row, :body_frame_damping) ? row.body_frame_damping : nothing,
+                    :world_frame_damping => row -> haskey(row, :world_frame_damping) ? row.world_frame_damping : nothing
                 ))
 
             point.pos_w .= point.pos_cad
@@ -599,13 +599,13 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                 [:l0, :diameter_mm, :unit_stiffness,
                  :unit_damping, :compression_frac];
                 mappings=Dict(
-                    :set => r -> resolved_set,
-                    :point_i => r -> yaml_to_ref(r.point_i),
-                    :point_j => r -> yaml_to_ref(r.point_j),
-                    :name => r -> begin
-                        if haskey(r, :name) &&
-                                !isnothing(r.name)
-                            Symbol(r.name)
+                    :set => row -> resolved_set,
+                    :point_i => row -> yaml_to_ref(row.point_i),
+                    :point_j => row -> yaml_to_ref(row.point_j),
+                    :name => row -> begin
+                        if haskey(row, :name) &&
+                                !isnothing(row.name)
+                            Symbol(row.name)
                         else
                             i
                         end
@@ -626,16 +626,16 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                 [:name, :segment_i, :segment_j, :type],
                 Vector{Union{}}();
                 mappings=Dict(
-                    :segment_i => r -> yaml_to_ref(r.segment_i),
-                    :segment_j => r -> yaml_to_ref(r.segment_j),
-                    :name => r -> begin
-                        if haskey(r, :name) && !isnothing(r.name)
-                            Symbol(r.name)
+                    :segment_i => row -> yaml_to_ref(row.segment_i),
+                    :segment_j => row -> yaml_to_ref(row.segment_j),
+                    :name => row -> begin
+                        if haskey(row, :name) && !isnothing(row.name)
+                            Symbol(row.name)
                         else
                             i  # Use index as name if no name provided
                         end
                     end,
-                    :type => r -> parse_dynamics_type(String(r.type))
+                    :type => row -> parse_dynamics_type(String(row.type))
                 ))
             push!(pulleys, pulley)
         end
@@ -655,16 +655,16 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                 [:name, :points, :type, :moment_frac],
                 [:damping];
                 mappings=Dict(
-                    :points => r -> [yaml_to_ref(p) for p in r.point_idxs],
-                    :name => r -> begin
-                        if haskey(r, :name) && !isnothing(r.name)
-                            Symbol(r.name)
+                    :points => row -> [yaml_to_ref(point) for point in row.point_idxs],
+                    :name => row -> begin
+                        if haskey(row, :name) && !isnothing(row.name)
+                            Symbol(row.name)
                         else
                             i  # Use index as name if no name provided
                         end
                     end,
-                    :type => r -> parse_dynamics_type(
-                        String(r.type))
+                    :type => row -> parse_dynamics_type(
+                        String(row.type))
                 ))
             push!(groups, group)
         end
@@ -690,8 +690,8 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                 !isnothing(row.segment_idxs)
             if has_segments
                 # Route 1: explicit segments
-                segs = [yaml_to_ref(s)
-                    for s in row.segment_idxs]
+                segment_refs = [yaml_to_ref(segment_ref)
+                    for segment_ref in row.segment_idxs]
                 start_ref = if hasfield(typeof(row),
                         :start_point) &&
                         !isnothing(row.start_point)
@@ -708,14 +708,14 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                 end
                 stretched_length, tether_force, stretch_frac =
                     parse_tether_init(row, tether_name)
-                tether = Tether(tether_name, segs, stretched_length;
+                tether = Tether(tether_name, segment_refs, stretched_length;
                     start_point=start_ref, end_point=end_ref,
                     tether_force, stretch_frac)
             else
                 # Route 2: auto-generation
                 start_ref = yaml_to_ref(row.start_point)
                 end_ref = yaml_to_ref(row.end_point)
-                n_seg = Int(row.n_segments)
+                n_segments = Int(row.n_segments)
                 stretched_length, tether_force, stretch_frac =
                     parse_tether_init(row, tether_name)
                 # Resolve material reference if present
@@ -724,25 +724,25 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                 props = Dict{Symbol, Any}(
                     pairs(resolved))
                 calculate_derived_properties!(props)
-                us = get(props, :unit_stiffness,
+                unit_stiffness = get(props, :unit_stiffness,
                     NaN)
-                us = isnothing(us) ? NaN :
-                    Float64(us)
-                ud = get(props, :unit_damping,
+                unit_stiffness = isnothing(unit_stiffness) ? NaN :
+                    Float64(unit_stiffness)
+                unit_damping = get(props, :unit_damping,
                     NaN)
-                ud = isnothing(ud) ? NaN :
-                    Float64(ud)
-                d_mm = get(props, :diameter_mm,
+                unit_damping = isnothing(unit_damping) ? NaN :
+                    Float64(unit_damping)
+                diameter_mm = get(props, :diameter_mm,
                     NaN)
-                d_mm = isnothing(d_mm) ? NaN :
-                    Float64(d_mm)
-                d = isnan(d_mm) ? NaN :
-                    d_mm * 0.001
+                diameter_mm = isnothing(diameter_mm) ? NaN :
+                    Float64(diameter_mm)
+                diameter = isnan(diameter_mm) ? NaN :
+                    diameter_mm * 0.001
                 tether = Tether(tether_name, stretched_length;
                     start_point=start_ref, end_point=end_ref,
-                    n_segments=n_seg,
-                    unit_stiffness=us, unit_damping=ud,
-                    diameter=d, tether_force, stretch_frac)
+                    n_segments,
+                    unit_stiffness, unit_damping,
+                    diameter, tether_force, stretch_frac)
             end
             push!(tethers, tether)
         end
@@ -762,16 +762,16 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                 [:winch_point, :init_vel,
                  :brake, :speed_controlled, :friction_epsilon];
                 mappings=Dict(
-                    :set => r -> resolved_set,
-                    :tethers => r -> [yaml_to_ref(t)
-                        for t in r.tether_idxs],
-                    :winch_point => r -> begin
-                        yaml_to_ref(r.winch_point)
+                    :set => row -> resolved_set,
+                    :tethers => row -> [yaml_to_ref(tether_ref)
+                        for tether_ref in row.tether_idxs],
+                    :winch_point => row -> begin
+                        yaml_to_ref(row.winch_point)
                     end,
-                    :name => r -> begin
-                        if haskey(r, :name) &&
-                           !isnothing(r.name)
-                            Symbol(r.name)
+                    :name => row -> begin
+                        if haskey(row, :name) &&
+                           !isnothing(row.name)
+                            Symbol(row.name)
                         else
                             i
                         end
@@ -792,10 +792,10 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
         for (i, row) in enumerate(wing_rows)
             # Use provided dynamics_type parameter or parse from YAML
             # Support old `type` field with deprecation warning
-            wt = if !isnothing(dynamics_type)
+            resolved_wing_type = if !isnothing(dynamics_type)
                 dynamics_type
             else
-                raw_wt_field = if hasfield(typeof(row), :dynamics_type) && !isnothing(row.dynamics_type)
+                raw_type_field = if hasfield(typeof(row), :dynamics_type) && !isnothing(row.dynamics_type)
                     String(row.dynamics_type)
                 elseif hasfield(typeof(row), :type) && !isnothing(row.type)
                     @warn "Wing YAML field `type` is deprecated; rename to `dynamics_type`."
@@ -803,25 +803,26 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                 else
                     error("Wing entry missing required `dynamics_type` field.")
                 end
-                parse_wing_type(raw_wt_field)
+                parse_wing_type(raw_type_field)
             end
 
             # Build kwargs based on wing type - SystemStructure handles resolution
             # Determine aero_mode: kwarg > YAML > default
-            am = if !isnothing(aero_mode)
+            resolved_aero_mode = if !isnothing(aero_mode)
                 aero_mode
             elseif hasfield(typeof(row), :aero_mode) &&
                     !isnothing(row.aero_mode)
                 parse_aero_mode(String(row.aero_mode))
             else
-                wt == RIGID_DYNAMICS ? AERO_LINEARIZED :
+                resolved_wing_type == RIGID_DYNAMICS ? AERO_LINEARIZED :
                     AERO_DIRECT
             end
 
-            if am == AERO_PLATE
+            if resolved_aero_mode == AERO_PLATE
                 # PlateWing — load surfaces and CL/CD from settings
                 wing = _load_plate_wing(row, i, data,
-                    resolved_set, wt, am, yaml_to_ref,
+                    resolved_set, resolved_wing_type, resolved_aero_mode,
+                    yaml_to_ref,
                     yaml_parse_ref_points,
                     yaml_parse_origin)
                 push!(wings, wing)
@@ -834,7 +835,7 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                       "was not provided.")
             end
 
-            if wt == PARTICLE_DYNAMICS
+            if resolved_wing_type == PARTICLE_DYNAMICS
                 # PARTICLE_DYNAMICS wings need z_ref_points, y_ref_points, origin
                 # Pass raw values - constructor handles defaults
                 wing = call_yaml_constructor(VSMWing, row,
@@ -844,37 +845,37 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                      :z_ref_points, :y_ref_points, :origin, :pos_cad,
                      :aero_scale_chord];
                     mappings=Dict(
-                        :set => r -> resolved_set,
-                        :groups => r -> hasfield(typeof(r), :groups) &&
-                            !isnothing(r.groups) ?
-                            [yaml_to_ref(g) for g in r.groups] : [],
-                        :vsm_set => r -> vsm_set,
-                        :dynamics_type => r -> wt,
-                        :aero_mode => r -> am,
-                        :name => r -> begin
-                            if haskey(r, :name) && !isnothing(r.name)
-                                Symbol(r.name)
+                        :set => row -> resolved_set,
+                        :groups => row -> hasfield(typeof(row), :groups) &&
+                            !isnothing(row.groups) ?
+                            [yaml_to_ref(group_ref) for group_ref in row.groups] : [],
+                        :vsm_set => row -> vsm_set,
+                        :dynamics_type => row -> resolved_wing_type,
+                        :aero_mode => row -> resolved_aero_mode,
+                        :name => row -> begin
+                            if haskey(row, :name) && !isnothing(row.name)
+                                Symbol(row.name)
                             else
                                 i  # Use index as name if no name provided
                             end
                         end,
-                        :transform => r -> begin
-                            if hasfield(typeof(r), :transform_idx) && !isnothing(r.transform_idx)
-                                yaml_to_ref(r.transform_idx)
+                        :transform => row -> begin
+                            if hasfield(typeof(row), :transform_idx) && !isnothing(row.transform_idx)
+                                yaml_to_ref(row.transform_idx)
                             else
                                 nothing  # Constructor handles default
                             end
                         end,
-                        :z_ref_points => r ->
-                            yaml_parse_ref_points(r, :z_ref_points),
-                        :y_ref_points => r ->
-                            yaml_parse_ref_points(r, :y_ref_points),
-                        :origin => r ->
-                            yaml_parse_origin(r, :origin_idx),
-                        :aero_scale_chord => r ->
-                            hasfield(typeof(r), :aero_scale_chord) && !isnothing(r.aero_scale_chord) ?
-                                float(r.aero_scale_chord) : 0.0,
-                        :pos_cad => r -> begin
+                        :z_ref_points => row ->
+                            yaml_parse_ref_points(row, :z_ref_points),
+                        :y_ref_points => row ->
+                            yaml_parse_ref_points(row, :y_ref_points),
+                        :origin => row ->
+                            yaml_parse_origin(row, :origin_idx),
+                        :aero_scale_chord => row ->
+                            hasfield(typeof(row), :aero_scale_chord) && !isnothing(row.aero_scale_chord) ?
+                                float(row.aero_scale_chord) : 0.0,
+                        :pos_cad => row -> begin
                             # Note: pos_cad will be set from origin point position after resolution
                             # For now, return nothing - SystemStructure will handle this
                             nothing
@@ -889,45 +890,45 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                      :aero_z_offset, :pos_cad,
                      :z_ref_points, :y_ref_points, :origin];
                     mappings=Dict(
-                        :set => r -> resolved_set,
-                        :aero_mode => r -> am,
-                        :groups => r -> hasfield(typeof(r), :groups) &&
-                            !isnothing(r.groups) ?
-                            [yaml_to_ref(g) for g in r.groups] : [],
-                        :vsm_set => r -> vsm_set,
-                        :dynamics_type => r -> wt,
-                        :name => r -> begin
-                            if haskey(r, :name) && !isnothing(r.name)
-                                Symbol(r.name)
+                        :set => row -> resolved_set,
+                        :aero_mode => row -> resolved_aero_mode,
+                        :groups => row -> hasfield(typeof(row), :groups) &&
+                            !isnothing(row.groups) ?
+                            [yaml_to_ref(group_ref) for group_ref in row.groups] : [],
+                        :vsm_set => row -> vsm_set,
+                        :dynamics_type => row -> resolved_wing_type,
+                        :name => row -> begin
+                            if haskey(row, :name) && !isnothing(row.name)
+                                Symbol(row.name)
                             else
                                 i
                             end
                         end,
-                        :transform => r -> begin
-                            if hasfield(typeof(r), :transform_idx) &&
-                               !isnothing(r.transform_idx)
-                                yaml_to_ref(r.transform_idx)
+                        :transform => row -> begin
+                            if hasfield(typeof(row), :transform_idx) &&
+                               !isnothing(row.transform_idx)
+                                yaml_to_ref(row.transform_idx)
                             else
                                 nothing
                             end
                         end,
-                        :pos_cad => r -> begin
-                            if !hasfield(typeof(r), :pos_cad) ||
-                               r.pos_cad === nothing
+                        :pos_cad => row -> begin
+                            if !hasfield(typeof(row), :pos_cad) ||
+                               row.pos_cad === nothing
                                 return nothing
                             end
-                            KVec3(r.pos_cad...)
+                            KVec3(row.pos_cad...)
                         end,
-                        :aero_scale_chord => r ->
-                            hasfield(typeof(r), :aero_scale_chord) &&
-                            !isnothing(r.aero_scale_chord) ?
-                                float(r.aero_scale_chord) : 0.0,
-                        :z_ref_points => r ->
-                            yaml_parse_ref_points(r, :z_ref_points),
-                        :y_ref_points => r ->
-                            yaml_parse_ref_points(r, :y_ref_points),
-                        :origin => r ->
-                            yaml_parse_origin(r, :origin_idx)
+                        :aero_scale_chord => row ->
+                            hasfield(typeof(row), :aero_scale_chord) &&
+                            !isnothing(row.aero_scale_chord) ?
+                                float(row.aero_scale_chord) : 0.0,
+                        :z_ref_points => row ->
+                            yaml_parse_ref_points(row, :z_ref_points),
+                        :y_ref_points => row ->
+                            yaml_parse_ref_points(row, :y_ref_points),
+                        :origin => row ->
+                            yaml_parse_origin(row, :origin_idx)
                     ))
             end
             push!(wings, wing)
@@ -950,40 +951,40 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                  :wing, :rot_point,
                  :elevation_vel, :azimuth_vel, :turn_rate];
                 mappings=Dict(
-                    :elevation => r -> deg2rad(r.elevation),
-                    :azimuth => r -> deg2rad(r.azimuth),
-                    :heading => r -> deg2rad(r.heading),
-                    :elevation_vel => r -> hasfield(typeof(r), :elevation_vel) && !isnothing(r.elevation_vel) ?
-                        deg2rad(r.elevation_vel) : 0.0,
-                    :azimuth_vel => r -> hasfield(typeof(r), :azimuth_vel) && !isnothing(r.azimuth_vel) ?
-                        deg2rad(r.azimuth_vel) : 0.0,
-                    :turn_rate => r -> hasfield(typeof(r), :turn_rate) && !isnothing(r.turn_rate) ?
-                        deg2rad(r.turn_rate) : 0.0,
-                    :base_pos => r -> KVec3(r.base_pos...),
-                    :base_point => r -> yaml_to_ref(r.base_point_idx),
-                    :base_transform => r -> begin
-                        if hasfield(typeof(r), :base_transform_idx) && !isnothing(r.base_transform_idx)
-                            yaml_to_ref(r.base_transform_idx)
+                    :elevation => row -> deg2rad(row.elevation),
+                    :azimuth => row -> deg2rad(row.azimuth),
+                    :heading => row -> deg2rad(row.heading),
+                    :elevation_vel => row -> hasfield(typeof(row), :elevation_vel) && !isnothing(row.elevation_vel) ?
+                        deg2rad(row.elevation_vel) : 0.0,
+                    :azimuth_vel => row -> hasfield(typeof(row), :azimuth_vel) && !isnothing(row.azimuth_vel) ?
+                        deg2rad(row.azimuth_vel) : 0.0,
+                    :turn_rate => row -> hasfield(typeof(row), :turn_rate) && !isnothing(row.turn_rate) ?
+                        deg2rad(row.turn_rate) : 0.0,
+                    :base_pos => row -> KVec3(row.base_pos...),
+                    :base_point => row -> yaml_to_ref(row.base_point_idx),
+                    :base_transform => row -> begin
+                        if hasfield(typeof(row), :base_transform_idx) && !isnothing(row.base_transform_idx)
+                            yaml_to_ref(row.base_transform_idx)
                         else
                             nothing
                         end
                     end,
-                    :rot_point => r -> begin
-                        if hasfield(typeof(r), :rot_point_idx) && !isnothing(r.rot_point_idx)
-                            yaml_to_ref(r.rot_point_idx)
+                    :rot_point => row -> begin
+                        if hasfield(typeof(row), :rot_point_idx) && !isnothing(row.rot_point_idx)
+                            yaml_to_ref(row.rot_point_idx)
                         else
                             nothing
                         end
                     end,
-                    :wing => r -> begin
-                        if !hasfield(typeof(r), :wing_idx) || r.wing_idx === nothing
+                    :wing => row -> begin
+                        if !hasfield(typeof(row), :wing_idx) || row.wing_idx === nothing
                             return nothing
                         end
-                        yaml_to_ref(r.wing_idx)
+                        yaml_to_ref(row.wing_idx)
                     end,
-                    :name => r -> begin
-                        if haskey(r, :name) && !isnothing(r.name)
-                            Symbol(r.name)
+                    :name => row -> begin
+                        if haskey(row, :name) && !isnothing(row.name)
+                            Symbol(row.name)
                         else
                             i  # Use index as name if no name provided
                         end

--- a/src/yaml_loader.jl
+++ b/src/yaml_loader.jl
@@ -760,7 +760,7 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
             winch = call_yaml_constructor(Winch, row,
                 [:name, :set, :tethers],
                 [:winch_point, :init_vel,
-                 :brake, :friction_epsilon];
+                 :brake, :speed_controlled, :friction_epsilon];
                 mappings=Dict(
                     :set => r -> resolved_set,
                     :tethers => r -> [yaml_to_ref(t)

--- a/test/test_deserialization.jl
+++ b/test/test_deserialization.jl
@@ -14,7 +14,8 @@ end
 
 using Test
 using SymbolicAWEModels
-using SymbolicAWEModels: KVec3, MVec3
+using SymbolicAWEModels: KVec3, MVec3, WING, PARTICLE_DYNAMICS,
+    VortexStepMethod
 using KiteUtils
 using LinearAlgebra
 
@@ -145,5 +146,45 @@ system:
             sam2.sys_struct.points[:test_point].vel_w)
         # Z velocity should be negative (falling in NED)
         @test vel_with_grav[3] < -0.5
+    end
+
+    @testset "Cached PARTICLE model applies per-point aero" begin
+        plate_src = joinpath(dirname(@__DIR__), "data", "2plate_kite")
+        plate_dir = joinpath(mktempdir(), "2plate_kite")
+        cp(plate_src, plate_dir; force=true)
+        set_data_path(plate_dir)
+        refine_yaml = joinpath(plate_dir,
+            "particle_structural_geometry.yaml")
+        vsm_set = VortexStepMethod.VSMSettings(
+            joinpath(plate_dir, "vsm_settings.yaml"); data_prefix=false)
+
+        function build_refine(; remake)
+            set = Settings("system.yaml")
+            set.g_earth = 0.0
+            sys = load_sys_struct_from_yaml(refine_yaml;
+                system_name="deser_refine", set,
+                dynamics_type=PARTICLE_DYNAMICS, vsm_set)
+            sys.winches[:main_winch].brake = true
+            sam = SymbolicAWEModel(set, sys)
+            init!(sam; remake, remake_vsm=false, prn=false)
+            for _ in 1:5
+                next_step!(sam; dt=1/300, vsm_interval=1)
+            end
+            sam
+        end
+
+        sam_fresh = build_refine(; remake=true)    # builds + caches
+        sam_cached = build_refine(; remake=false)  # loads from .bin
+
+        wpts(sam) = [p for p in sam.sys_struct.points if p.type == WING]
+        fresh, cached = wpts(sam_fresh), wpts(sam_cached)
+
+        # wind is on → aero is non-trivial (test is meaningful)
+        @test sum(norm(p.aero_force_b) for p in cached) > 1.0
+        # cache load must apply the same aero as a fresh build
+        @test maximum(norm(pf.force - pc.force)
+                      for (pf, pc) in zip(fresh, cached)) < 1e-2
+        @test maximum(norm(pf.pos_w - pc.pos_w)
+                      for (pf, pc) in zip(fresh, cached)) < 1e-4
     end
 end


### PR DESCRIPTION
## Separate out aero into a swappable component

Reworks aero coupling to mirror the winch interface (`Winch.model` /
`default_winch_component`): each wing carries an `aero_model` builder, and a new
`AERO_CUSTOM` mode lets a researcher plug in their own aerodynamics by providing
a component, with no SAM-internal edits.

### Why

The previous attempt registered an array function per wing
(`wing_force_moment -> SVector{6}` plus a variable-length `twists` input).
That always materialised heap `Vector`s at the MTK ↔ registered-function
boundary, so the ODE RHS allocated (≈6 allocs/step) and could not be made
zero-alloc without dropping the array interface.

An MTK **subsystem** sidesteps this entirely: `mtkcompile` flattens the
component, so every connector — including the per-group twist array — becomes an
inlined symbolic unknown. Nothing crosses a registered-function boundary, so we
get the extension point *and* keep the zero-alloc RHS, instead of fighting for
it.

### Design

- A wing always goes through `aero_model`. `aero_mode` selects a built-in
  default builder (`default_aero_none` / `default_aero_direct` /
  `default_aero_linearized`); `AERO_CUSTOM` requires an explicit `aero_model`.
- Builder signature `aero_model(sys_struct, wing_idx; name) -> System`, validated
  by `validate_aero_component`. Connector contract (all body-frame), per
  `dynamics_type`:
  - **RIGID** (`ng = length(group_idxs)`): in `va[3]`, `rho`, `R_b_w[3,3]`,
    `omega[3]`, `twist[ng]`, `twist_vel[ng]`; out `force[3]`, `moment[3]`,
    `twist_moment[ng]`.
  - **PARTICLE** (`np` WING points): in `point_pos[3,np]`, `point_vel[3,np]`;
    out `point_force[3,np]`.
- `vsm_eqs.jl` becomes a thin winch-style wiring layer (instantiate → validate →
  drive inputs → read outputs); aero components are attached as subsystems
  alongside the winch subsystems in `create_sys.jl`.
- `nameof(wing.aero_model)` is folded into the model hash. Because a custom
  builder's *equations* aren't captured by the hash, `init!` now defaults
  `remake` to rebuild automatically when a custom winch/aero component is present
  (`has_custom_component`), with a `prn` info message.

### Decisions worth noting

- `pos` was dropped from the RIGID contract; a scalar `rho` input was added
  because the linearized built-in needs live air density
  (`q∞ = ½·rho(height)·va·va`) — the one environmental quantity a built-in needs.
- Orientation is exposed as the rotation matrix `R_b_w` rather than a quaternion:
  the parent already carries `R_b_to_w` symbolically, and a quaternion would
  force a per-step matrix→quaternion conversion the built-ins never use. Easy to
  switch if a quaternion is preferred.
- `AERO_LINEARIZED` + `PARTICLE` errors at build time (no such path).

### Validation (clean precompile)

| Test | Result | Covers |
|---|---|---|
| `test_bench` | 15/15, **RHS allocs 0 (0 B)** | rigid linearized + zero-alloc |
| `test_wing_dynamics` | 20/20 | rigid `AERO_NONE` dynamics |
| `test_twist_alignment` | 7/7 | rigid linearized + twist + quasi-static |
| `test_wing` | 99/99 | rigid linearized + particle direct, force-conservation match |
| custom smoke test | force `[0,0,5]` flows through; auto-remake fires | `AERO_CUSTOM` end-to-end |

The `test_wing` force-conservation checks confirm the reconstruction matches the
VSM solve (particle direct is exact; rigid linearized tracks closely). Full
suite not yet run — `test_deserialization.jl` (subsystem `.bin` round-trip) is
the highest-value remaining check.

### Note

`bin/run_julia` is included in this branch but is unrelated to the aero work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
