### PR TITLE
Fix for twist surfaces

### DIFF
--- a/bin/run_julia
+++ b/bin/run_julia
@@ -10,31 +10,65 @@ export JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager
 
 . ./bin/setup_env
 
+# --kaimon forces kaimon on and skips autodetection; remaining args go to Julia.
+force_kaimon=false
+julia_extra_args=()
+for arg in "$@"; do
+    if [[ "$arg" == "--kaimon" ]]; then
+        force_kaimon=true
+    else
+        julia_extra_args+=("$arg")
+    fi
+done
+
+USE_KAIMON=false
+
 julia_version=$(julia --version | awk '{print($3)}')
 julia_major=${julia_version:0:3} 
 if [[ $julia_major == "1.1" ]]; then
     julia_major=${julia_version:0:4} 
 fi
 
-if [[ $HOSTNAME == "ufryzen" || $HOSTNAME == "framework" ]]; then
-    GCT="--gcthreads=8,1"
-    # export NO_MTK=true
-    # export USE_V9=true
-else
-    GCT="--gcthreads=4,1"
+# Kaimon integration requires Julia >= 1.12.
+kaimon_supported=false
+if [[ "$(printf '%s\n' 1.12 "$julia_version" | sort -V | head -n1)" == "1.12" ]]; then
+    kaimon_supported=true
 fi
 
-if [[ $# -gt 0 ]]; then
-    JULIA_ARGS=("$@")
-else
-    JULIA_ARGS=(-i -e 'function menu(); include("examples/menu.jl"); end')
+# KAIMON_AUTODETECT=true detects kaimon from a listener on port 2828.
+if [[ "$force_kaimon" == "true" ]]; then
+    USE_KAIMON=true
+elif [[ "${KAIMON_AUTODETECT:-false}" == "true" ]]; then
+    if command -v ss &> /dev/null; then
+        if ss -ltn '( sport = :2828 )' | grep -q ':2828'; then
+            USE_KAIMON=true
+        fi
+    elif command -v lsof &> /dev/null; then
+        if lsof -nP -iTCP:2828 -sTCP:LISTEN &> /dev/null; then
+            USE_KAIMON=true
+        fi
+    fi
 fi
 
-THREADS="auto"
+if [[ "$USE_KAIMON" == "true" && "$kaimon_supported" != "true" ]]; then
+    echo "Warning: kaimon requires Julia >= 1.12, found $julia_version. Disabling kaimon." >&2
+    USE_KAIMON=false
+fi
+
+julia_init='using Revise; '
+if [[ "$USE_KAIMON" == "true" ]]; then
+    julia_init+='using Kaimon; Gate.serve(); '
+fi
+
+if [[ ${#julia_extra_args[@]} -gt 0 ]]; then
+    JULIA_ARGS=("${julia_extra_args[@]}")
+else
+    JULIA_ARGS=(-i -e "menu() = include(\"examples/menu.jl\"); $julia_init")
+fi
 
 if test -f "bin/kps-image-${julia_major}.so"; then
     echo "Found system image!"
-    julia +${julia_major} -J  bin/kps-image-${julia_major}.so -t $THREADS $GCT --project "${JULIA_ARGS[@]}"
+    julia --project -J "bin/kps-image-${julia_major}.so" "${JULIA_ARGS[@]}"
 else
-    julia +${julia_major}  -t $THREADS $GCT --project "${JULIA_ARGS[@]}"
+    julia --project "${JULIA_ARGS[@]}"
 fi

--- a/ext/SymbolicAWEModelsMakieExt.jl
+++ b/ext/SymbolicAWEModelsMakieExt.jl
@@ -2170,21 +2170,21 @@ function setup_segment_hover_events!(scene, systems::Vector{<:SystemStructure},
     segment_label_pos = Observable(Point2f(0, 0))
     segment_label_visible = Observable(false)
     text!(scene, segment_label, position=segment_label_pos, space=:pixel,
-          fontsize=14, color=:white, strokecolor=:black, strokewidth=1,
+          fontsize=14, color=:black, overdraw=true,
           align=(:center, :center), visible=segment_label_visible, transparency=true)
 
     point1_label = Observable("")
     point1_label_pos = Observable(Point2f(0, 0))
     point1_label_visible = Observable(false)
     text!(scene, point1_label, position=point1_label_pos, space=:pixel,
-          fontsize=14, color=:white, strokecolor=:black, strokewidth=1,
+          fontsize=14, color=:black, overdraw=true,
           align=(:center, :center), visible=point1_label_visible, transparency=true)
 
     point2_label = Observable("")
     point2_label_pos = Observable(Point2f(0, 0))
     point2_label_visible = Observable(false)
     text!(scene, point2_label, position=point2_label_pos, space=:pixel,
-          fontsize=14, color=:white, strokecolor=:black, strokewidth=1,
+          fontsize=14, color=:black, overdraw=true,
           align=(:center, :center), visible=point2_label_visible, transparency=true)
 
     # --- Hover handler: find closest segment across ALL systems ---
@@ -2365,7 +2365,7 @@ function setup_body_zoom_events!(scene, sys; relmargin=0.2,
     body_label_pos = Observable(Point2f(0, 0))
     body_label_visible = Observable(false)
     text!(scene, body_label, position=body_label_pos, space=:pixel,
-          fontsize=14, color=:white, strokecolor=:black, strokewidth=1,
+          fontsize=14, color=:black, overdraw=true,
           align=(:center, :center), visible=body_label_visible, transparency=true)
 
     # Min 2D distance from the cursor to any of body `b`'s joint spokes.

--- a/ext/SymbolicAWEModelsMakieExt.jl
+++ b/ext/SymbolicAWEModelsMakieExt.jl
@@ -3083,6 +3083,11 @@ function setup_replay_controls!(scene, n_frames, update_frame!, get_time, get_dt
                 # Check play button
                 if mp[1] >= play_button_rect.origin[1] && mp[1] <= play_button_rect.origin[1] + play_button_rect.widths[1] &&
                    mp[2] >= play_button_rect.origin[2] && mp[2] <= play_button_rect.origin[2] + play_button_rect.widths[2]
+                    # Restart from beginning if at the end
+                    if frame_idx[] >= n_frames
+                        frame_idx[] = 1
+                        update_frame!(1)
+                    end
                     is_playing[] = !is_playing[]
                     return Consume(true)
                 end

--- a/src/aero_modes/common.jl
+++ b/src/aero_modes/common.jl
@@ -366,7 +366,8 @@ function remake_aero!(mode::AbstractVSMAero, wing, set, vsm_set, points,
         "remake_aero!: VSM wing $(wing.idx) needs a VSMSettings, " *
         "got $(typeof(vsm_set)).")
     wing.vsm_wing = create_vsm_wing(set, vsm_set;
-        prn=false, sort_sections=false)
+        prn=false, sort_sections=false,
+        n_unrefined_sections=length(wing.twist_surface_idxs))
     wing.vsm_aero = VortexStepMethod.BodyAerodynamics([wing.vsm_wing])
     wing.vsm_solver = VortexStepMethod.Solver(wing.vsm_aero, vsm_set)
 

--- a/src/generate_system/twist_surface_eqs.jl
+++ b/src/generate_system/twist_surface_eqs.jl
@@ -199,7 +199,8 @@ function twist_surface_eqs!(eqs, defaults, twist_surfaces, bodies, params, initi
                     fix_wing == true,
                     0,
                     twist_α[twist_surface.idx] -
-                    params.twist_surfaces[twist_surface.idx].damping * twist_ω[twist_surface.idx],
+                    params.twist_surfaces[twist_surface.idx].damping * twist_ω[twist_surface.idx] -
+                    params.twist_surfaces[twist_surface.idx].stiffness * twist_angle[twist_surface.idx],
                 )
             ]
             defaults = [

--- a/src/generate_system/twist_surface_eqs.jl
+++ b/src/generate_system/twist_surface_eqs.jl
@@ -71,6 +71,12 @@ function twist_surface_eqs!(eqs, defaults, twist_surfaces, bodies, params, initi
 
     length(twist_surfaces) == 0 && return eqs, defaults
 
+    # Twist surfaces may have differing point counts (e.g. left/right halves of a
+    # bridle with an asymmetric number of attachment points). Size the per-point
+    # arrays by the largest point count so every twist_surface fits, and fill the
+    # unused tail slots with zero equations below so the system stays balanced.
+    max_npoints = maximum(length(ts.point_idxs) for ts in twist_surfaces)
+
     @variables begin
         trailing_edge_angle(t)[eachindex(twist_surfaces)]
         trailing_edge_ω(t)[eachindex(twist_surfaces)]
@@ -79,10 +85,10 @@ function twist_surface_eqs!(eqs, defaults, twist_surfaces, bodies, params, initi
         twist_α(t)[eachindex(twist_surfaces)]
         twist_surface_tether_force(t)[eachindex(twist_surfaces)]
         twist_surface_tether_moment(t)[eachindex(twist_surfaces)]
-        tether_force(t)[eachindex(twist_surfaces[1].point_idxs), eachindex(twist_surfaces)]
-        tether_moment(t)[eachindex(twist_surfaces[1].point_idxs), eachindex(twist_surfaces)]
-        r_twist_surface(t)[eachindex(twist_surfaces[1].point_idxs), eachindex(twist_surfaces)]
-        r_vec(t)[1:3, eachindex(twist_surfaces[1].point_idxs), eachindex(twist_surfaces)]
+        tether_force(t)[1:max_npoints, eachindex(twist_surfaces)]
+        tether_moment(t)[1:max_npoints, eachindex(twist_surfaces)]
+        r_twist_surface(t)[1:max_npoints, eachindex(twist_surfaces)]
+        r_vec(t)[1:3, 1:max_npoints, eachindex(twist_surfaces)]
     end
 
     for twist_surface in twist_surfaces
@@ -118,6 +124,10 @@ function twist_surface_eqs!(eqs, defaults, twist_surfaces, bodies, params, initi
                 twist_ω[twist_surface.idx] ~ 0
                 twist_surface_tether_force[twist_surface.idx] ~ 0
                 twist_surface_tether_moment[twist_surface.idx] ~ 0
+                [tether_force[i, twist_surface.idx] ~ 0 for i in 1:max_npoints]
+                [tether_moment[i, twist_surface.idx] ~ 0 for i in 1:max_npoints]
+                [r_twist_surface[i, twist_surface.idx] ~ 0 for i in 1:max_npoints]
+                [r_vec[j, i, twist_surface.idx] ~ 0 for i in 1:max_npoints for j in 1:3]
             ]
             (!no_aero && isempty(twist_surface.unrefined_section_idxs)) &&
                 (eqs = [eqs; twist_surface_aero_moment[twist_surface.idx] ~ 0])
@@ -147,6 +157,20 @@ function twist_surface_eqs!(eqs, defaults, twist_surfaces, bodies, params, initi
                 r_twist_surface[i, twist_surface.idx] ~ rv ⋅ smooth_normalize(gc)
                 tether_force[i, twist_surface.idx] ~ pf ⋅ Rz
                 tether_moment[i, twist_surface.idx] ~ r_twist_surface[i, twist_surface.idx] * tether_force[i, twist_surface.idx]
+            ]
+        end
+
+        # Zero out the unused tail rows for twist_surfaces with fewer than
+        # max_npoints points, so every declared array element gets exactly one
+        # equation regardless of how many points this particular surface has.
+        npoints = length(twist_surface.point_idxs)
+        if npoints < max_npoints
+            eqs = [
+                eqs
+                [tether_force[i, twist_surface.idx] ~ 0 for i in (npoints+1):max_npoints]
+                [tether_moment[i, twist_surface.idx] ~ 0 for i in (npoints+1):max_npoints]
+                [r_twist_surface[i, twist_surface.idx] ~ 0 for i in (npoints+1):max_npoints]
+                [r_vec[j, i, twist_surface.idx] ~ 0 for i in (npoints+1):max_npoints for j in 1:3]
             ]
         end
 

--- a/src/generate_system/twist_surface_eqs.jl
+++ b/src/generate_system/twist_surface_eqs.jl
@@ -200,7 +200,8 @@ function twist_surface_eqs!(eqs, defaults, twist_surfaces, bodies, params, initi
                     0,
                     twist_α[twist_surface.idx] -
                     params.twist_surfaces[twist_surface.idx].damping * twist_ω[twist_surface.idx] -
-                    params.twist_surfaces[twist_surface.idx].stiffness * twist_angle[twist_surface.idx],
+                    params.twist_surfaces[twist_surface.idx].stiffness * twist_angle[twist_surface.idx] /
+                    inertia,
                 )
             ]
             defaults = [

--- a/src/system_structure/system_structure_core.jl
+++ b/src/system_structure/system_structure_core.jl
@@ -704,7 +704,7 @@ and `Ry` is a rotation about the Y axis by angle
 
 Unlike the generic [`principal_frame`](@ref) (full 3-axis eigendecomposition +
 a discrete permutation search), this is a closed-form, unique solution
-constrained to a rotation about Y — the right choice for a wing that's
+constrained to a rotation about Y, for a wing that's
 symmetric about the XZ-plane (no Y products of inertia), where a generic
 permutation search is ambiguous whenever two principal moments are close and
 can pick a qualitatively different (though equally valid) axis assignment

--- a/src/system_structure/system_structure_core.jl
+++ b/src/system_structure/system_structure_core.jl
@@ -693,6 +693,33 @@ end
 # ==================== CONSTRUCTOR ==================== #
 
 """
+    calc_inertia_y_rotation(I_tensor)
+
+Find the Y-axis rotation that diagonalizes the XZ block
+of the inertia tensor (zeros out `I[1,3]` and `I[3,1]`).
+
+Returns `(I_diag, Ry)` where `I_diag = Ry * I_tensor * Ry'`
+and `Ry` is a rotation about the Y axis by angle
+`θ = atan(2·I₁₃, I₁₁ − I₃₃) / 2`.
+
+Unlike the generic [`principal_frame`](@ref) (full 3-axis eigendecomposition +
+a discrete permutation search), this is a closed-form, unique solution
+constrained to a rotation about Y — the right choice for a wing that's
+symmetric about the XZ-plane (no Y products of inertia), where a generic
+permutation search is ambiguous whenever two principal moments are close and
+can pick a qualitatively different (though equally valid) axis assignment
+than the wing's actual CAD/aero-panel frame expects.
+"""
+function calc_inertia_y_rotation(I_tensor)
+    θ = atan(2 * I_tensor[1, 3],
+             I_tensor[1, 1] - I_tensor[3, 3]) / 2
+    cθ, sθ = cos(θ), sin(θ)
+    Ry = [cθ 0 sθ; 0 1 0; -sθ 0 cθ]
+    I_diag = Ry * I_tensor * Ry'
+    return I_diag, Ry
+end
+
+"""
     setup_wing_frame!(wing, points; prn=true)
 
 Compute a wing's body frame (`R_b_to_c`, `pos_cad`) and, for `RIGID_DYNAMICS`, its
@@ -709,9 +736,14 @@ function setup_wing_frame!(wing, points; prn=true)
         if !isnothing(inertia_normalized)
             # The hook returns per-unit-mass inertia [m²]; scale once here.
             I_cad = wing.mass .* inertia_normalized
-            inertia_principal, R_c_to_p = principal_frame(I_cad)
-            wing.R_p_to_c .= R_c_to_p'  # principal→CAD
-            wing.inertia_principal .= inertia_principal
+            # Wing-specific Y-axis-constrained diagonalization (not the generic
+            # `principal_frame`): a wing is symmetric about the XZ-plane, and
+            # this closed-form solution is the unique one, unlike the generic
+            # eigendecomposition's discrete permutation search (see
+            # `calc_inertia_y_rotation`'s docstring).
+            I_diag, Ry = calc_inertia_y_rotation(I_cad)
+            wing.R_p_to_c .= Ry'  # principal→CAD
+            wing.inertia_principal .= diag(I_diag)
         end
 
         # Body frame from ref points (else body = principal, origin = COM)

--- a/src/system_structure/types.jl
+++ b/src/system_structure/types.jl
@@ -400,6 +400,13 @@ mutable struct TwistSurface
     moment_frac::SimFloat
     "Damping coefficient for twist dynamics [N·m·s/rad]."
     damping::SimFloat
+    "Torsional restoring stiffness for twist dynamics [N·m/rad], applied the
+    same way as `damping` (subtracted directly from the twist angular
+    acceleration, not divided by inertia again). Models the panel's own
+    structural resistance to twisting, independent of any restoring moment
+    from bridle tension geometry. Defaults to 0.0 (no effect, matching prior
+    behaviour) when not set."
+    stiffness::SimFloat
     "Current twist angle [rad]."
     twist::SimFloat
     "Current twist angular velocity [rad/s]."
@@ -433,6 +440,9 @@ using the closest VSM panel to the twist_surface's mean point position.
 
 # Keyword Arguments
 - `damping::SimFloat=50.0`: Damping coefficient for twist dynamics.
+- `stiffness::SimFloat=0.0`: Torsional restoring stiffness [N·m/rad]. Adds a
+  `-stiffness * twist_angle` term to the twist dynamics, independent of the
+  bridle-tension restoring moment. `0.0` reproduces prior behaviour exactly.
 - `x_airf=nothing`: Chord-direction reference (body frame). When given, stored as
   the `chord` field — twist is measured relative to it. Defaults to auto-derived
   from the closest VSM panel during SystemStructure construction.
@@ -446,14 +456,14 @@ using the closest VSM panel to the twist_surface's mean point position.
   computed during SystemStructure construction from the closest VSM panel.
 """
 function TwistSurface(name, points, type, moment_frac;
-                      damping=50.0, x_airf=nothing, y_airf=nothing,
+                      damping=50.0, stiffness=0.0, x_airf=nothing, y_airf=nothing,
                       area=NaN, twist=0.0)
     point_refs = Vector{NameRef}([p isa Integer ? Int(p) : Symbol(p) for p in points])
     chord_vec = isnothing(x_airf) ? zeros(KVec3) : KVec3(x_airf)
     y_vec = isnothing(y_airf) ? zeros(KVec3) : KVec3(y_airf)
     TwistSurface(0, name, Int64[], point_refs,
           zeros(KVec3), chord_vec, y_vec,
-          type, moment_frac, damping,
+          type, moment_frac, damping, stiffness,
           SimFloat(twist), 0.0, 0.0, 0.0, 0.0,
           Int64[], SimFloat(area))
 end

--- a/src/system_structure/types.jl
+++ b/src/system_structure/types.jl
@@ -400,12 +400,13 @@ mutable struct TwistSurface
     moment_frac::SimFloat
     "Damping coefficient for twist dynamics [N·m·s/rad]."
     damping::SimFloat
-    "Torsional restoring stiffness for twist dynamics [N·m/rad], applied the
-    same way as `damping` (subtracted directly from the twist angular
-    acceleration, not divided by inertia again). Models the panel's own
-    structural resistance to twisting, independent of any restoring moment
-    from bridle tension geometry. Defaults to 0.0 (no effect, matching prior
-    behaviour) when not set."
+    "Torsional restoring stiffness for twist dynamics [N·m/rad]. The resulting
+    moment (`stiffness * twist_angle`) is divided by the twist_surface's
+    inertia, same as the aero/tether moments, before being applied to the
+    twist angular acceleration. Models the panel's own structural resistance
+    to twisting, independent of any restoring moment from bridle tension
+    geometry. Defaults to 0.0 (no effect, matching prior behaviour) when not
+    set."
     stiffness::SimFloat
     "Current twist angle [rad]."
     twist::SimFloat
@@ -441,8 +442,9 @@ using the closest VSM panel to the twist_surface's mean point position.
 # Keyword Arguments
 - `damping::SimFloat=50.0`: Damping coefficient for twist dynamics.
 - `stiffness::SimFloat=0.0`: Torsional restoring stiffness [N·m/rad]. Adds a
-  `-stiffness * twist_angle` term to the twist dynamics, independent of the
-  bridle-tension restoring moment. `0.0` reproduces prior behaviour exactly.
+  `-stiffness * twist_angle / inertia` term to the twist angular acceleration,
+  independent of the bridle-tension restoring moment. `0.0` reproduces prior
+  behaviour exactly.
 - `x_airf=nothing`: Chord-direction reference (body frame). When given, stored as
   the `chord` field — twist is measured relative to it. Defaults to auto-derived
   from the closest VSM panel during SystemStructure construction.

--- a/src/system_structure/wing.jl
+++ b/src/system_structure/wing.jl
@@ -341,6 +341,14 @@ it to the wing.
 - `point_to_vsm_point`, `wing_segments`: VSM structural↔panel maps.
 - `z_ref_points`, `y_ref_points`, `origin`: Body-frame references.
 - `aero_scale_chord`, `aero_z_offset`: VSM force/panel adjustments.
+- `n_unrefined_sections=nothing`: Number of coarse (unrefined) spanwise
+  sections used for twist/deformation control, before mesh refinement into
+  the full VSM panel mesh; also sizes the linearized aero I/O in
+  [`build_vsm_engine`](@ref) (twist_surface-count proxy). Only used for
+  `.obj`/`.dat`-based wings ([`create_vsm_wing`](@ref)); ignored when loading
+  from `aero_geometry.yaml`, where it is inferred from the geometry file's
+  sections instead. When `nothing`, defaults to `2` if
+  `set.physical_model == "simple_ram"`, else `6`.
 """
 function VSMWing(name, set::Settings,
                  twist_surfaces::AbstractVector,

--- a/src/system_structure/wing.jl
+++ b/src/system_structure/wing.jl
@@ -242,7 +242,7 @@ This function checks for .obj and .dat files in the model directory.
 If found, it uses `VortexStepMethod.ObjWing(obj_path, dat_path)` to load the wing.
 Otherwise, it falls back to loading from `aero_geometry.yaml`.
 """
-function create_vsm_wing(set::Settings, vsm_set::VortexStepMethod.VSMSettings; prn=true, sort_sections=true)
+function create_vsm_wing(set::Settings, vsm_set::VortexStepMethod.VSMSettings; prn=true, sort_sections=true, n_unrefined_sections=nothing)
     # Check for .obj and .dat files in the model directory
     model_dir = get_data_path()
     obj_path = joinpath(model_dir, set.model)
@@ -252,10 +252,12 @@ function create_vsm_wing(set::Settings, vsm_set::VortexStepMethod.VSMSettings; p
         # Use ObjWing constructor (default path)
         prn && @info "Loading wing from .obj/.dat files"
 
-        if set.physical_model == "simple_ram"
-            n_unrefined_sections = 2
-        else
-            n_unrefined_sections = 6
+        if isnothing(n_unrefined_sections)
+            if set.physical_model == "simple_ram"
+                n_unrefined_sections = 2
+            else
+                n_unrefined_sections = 6
+            end
         end
 
         return VortexStepMethod.ObjWing(obj_path, dat_path;
@@ -289,8 +291,10 @@ are resolved.
 function build_vsm_engine(set::Settings, vsm_set::VortexStepMethod.VSMSettings,
                           dynamics_type::WingType;
                           point_to_vsm_point=nothing, wing_segments=nothing,
-                          aero_scale_chord=0.0, aero_z_offset=0.0)
-    vsm_wing = create_vsm_wing(set, vsm_set; prn=false, sort_sections=false)
+                          aero_scale_chord=0.0, aero_z_offset=0.0,
+                          n_unrefined_sections=nothing)
+    vsm_wing = create_vsm_wing(set, vsm_set; prn=false, sort_sections=false,
+        n_unrefined_sections)
     vsm_aero = VortexStepMethod.BodyAerodynamics([vsm_wing])
     vsm_solver = VortexStepMethod.Solver(vsm_aero, vsm_set)
 
@@ -356,7 +360,8 @@ function VSMWing(name, set::Settings,
                  y_ref_points=nothing,
                  origin=nothing,
                  aero_scale_chord::SimFloat=0.0,
-                 aero_z_offset::SimFloat=0.0)
+                 aero_z_offset::SimFloat=0.0,
+                 n_unrefined_sections=nothing)
 
     # Handle deprecated wing_type keyword
     if !isnothing(wing_type)
@@ -391,7 +396,8 @@ function VSMWing(name, set::Settings,
             "Wing '$name': aero mode $(typeof(aero)) needs VSM geometry " *
             "but no vsm_set was provided.")
         aero = attach_engine!(aero, build_vsm_engine(set, vsm_set, dynamics_type;
-            point_to_vsm_point, wing_segments, aero_scale_chord, aero_z_offset))
+            point_to_vsm_point, wing_segments, aero_scale_chord, aero_z_offset,
+            n_unrefined_sections))
     end
 
     # Placeholders — overwritten by SystemStructure
@@ -415,9 +421,11 @@ function VSMWing(name, vsm_aero, vsm_wing, vsm_solver,
                  twist_surfaces::AbstractVector,
                  R_b_to_c::AbstractMatrix,
                  pos_cad::AbstractVector;
-                 transform=nothing)
+                 transform=nothing,
+                 n_unrefined_sections=nothing)
     inertia_vec = ones(MVector{3, SimFloat})
-    n_twist_surfaces_est = vsm_wing.n_unrefined_sections
+    n_twist_surfaces_est = isnothing(n_unrefined_sections) ?
+        vsm_wing.n_unrefined_sections : n_unrefined_sections
     num_aero_outputs = 6 + n_twist_surfaces_est
     num_aero_inputs = 5 + n_twist_surfaces_est
     engine = VSMEngine(vsm_aero, vsm_wing, vsm_solver,

--- a/src/system_structure/wing.jl
+++ b/src/system_structure/wing.jl
@@ -364,7 +364,7 @@ it to the wing.
   `.obj`/`.dat`-based wings ([`create_vsm_wing`](@ref)); ignored when loading
   from `aero_geometry.yaml`, where it is inferred from the geometry file's
   sections instead. When `nothing`, defaults to `2` if
-  `set.physical_model == "simple_ram"`, else `6`.
+  `set.physical_model == "simple_ram"`, else `4`.
 """
 function VSMWing(name, set::Settings,
                  twist_surfaces::AbstractVector,

--- a/src/system_structure/wing.jl
+++ b/src/system_structure/wing.jl
@@ -150,6 +150,9 @@ function validate_weights!(weights::Vector{Float64})
     end
 end
 
+"""Declare Wing as a generic function (not an extension of VortexStepMethod.Wing)."""
+function Wing end
+
 """
     Wing(name, twist_surfaces, R_b_to_c, pos_cad, inertia_principal;
          transform=nothing, y_damping=150.0, angular_damping=0.0,

--- a/src/system_structure/wing.jl
+++ b/src/system_structure/wing.jl
@@ -252,7 +252,7 @@ function create_vsm_wing(set::Settings, vsm_set::VortexStepMethod.VSMSettings; p
         if set.physical_model == "simple_ram"
             n_unrefined_sections = 2
         else
-            n_unrefined_sections = 4
+            n_unrefined_sections = 6
         end
 
         return VortexStepMethod.ObjWing(obj_path, dat_path;

--- a/src/yaml_loader.jl
+++ b/src/yaml_loader.jl
@@ -323,13 +323,16 @@ function load_wing(mode::AbstractAeroModel, row, idx, data, set, wing_type,
             [:transform, :y_damping, :angular_damping,
              :dynamics_type, :aero,
              :z_ref_points, :y_ref_points, :origin, :pos_cad,
-             :aero_scale_chord];
+             :aero_scale_chord, :n_unrefined_sections];
             mappings=Dict(
                 :set => row -> set,
                 :twist_surfaces => row -> hasfield(typeof(row), :twist_surfaces) &&
                     !isnothing(row.twist_surfaces) ?
                     [yaml_to_ref(twist_surface_ref) for twist_surface_ref in row.twist_surfaces] : [],
                 :vsm_set => row -> vsm_set,
+                :n_unrefined_sections => row -> hasfield(typeof(row), :twist_surfaces) &&
+                    !isnothing(row.twist_surfaces) ?
+                    length(row.twist_surfaces) : nothing,
                 :dynamics_type => row -> wing_type,
                 :aero => row -> mode,
                 :name => row -> begin
@@ -367,7 +370,8 @@ function load_wing(mode::AbstractAeroModel, row, idx, data, set, wing_type,
             [:transform, :y_damping, :angular_damping,
              :dynamics_type, :aero, :aero_scale_chord,
              :aero_z_offset, :pos_cad,
-             :z_ref_points, :y_ref_points, :origin];
+             :z_ref_points, :y_ref_points, :origin,
+             :n_unrefined_sections];
             mappings=Dict(
                 :set => row -> set,
                 :aero => row -> mode,
@@ -375,6 +379,9 @@ function load_wing(mode::AbstractAeroModel, row, idx, data, set, wing_type,
                     !isnothing(row.twist_surfaces) ?
                     [yaml_to_ref(twist_surface_ref) for twist_surface_ref in row.twist_surfaces] : [],
                 :vsm_set => row -> vsm_set,
+                :n_unrefined_sections => row -> hasfield(typeof(row), :twist_surfaces) &&
+                    !isnothing(row.twist_surfaces) ?
+                    length(row.twist_surfaces) : nothing,
                 :dynamics_type => row -> wing_type,
                 :name => row -> begin
                     if haskey(row, :name) && !isnothing(row.name)

--- a/src/yaml_loader.jl
+++ b/src/yaml_loader.jl
@@ -674,7 +674,7 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
             # Create TwistSurface using new constructor (name, points, type, moment_frac)
             twist_surface = call_yaml_constructor(TwistSurface, row,
                 [:name, :points, :type, :moment_frac],
-                [:damping];
+                [:damping, :stiffness];
                 mappings=Dict(
                     :points => row -> [yaml_to_ref(point) for point in row.point_idxs],
                     :name => row -> begin

--- a/test/test_inertia_y_rotation.jl
+++ b/test/test_inertia_y_rotation.jl
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2026 Uwe Fechner
+# SPDX-License-Identifier: LGPL-3.0-only
+
+# test_inertia_y_rotation.jl
+#
+# `calc_inertia_y_rotation` diagonalizes the XZ block of a wing's inertia
+# tensor with a closed-form Y-axis rotation, unique for a body symmetric
+# about the XZ-plane. `setup_wing_frame!` uses it instead of the generic
+# `principal_frame` (full eigendecomposition + permutation search), which
+# picks the axis assignment ambiguously whenever two principal moments are
+# close and can flip the body frame ~90° relative to the CAD/aero-panel frame.
+
+using Test
+using SymbolicAWEModels
+import SymbolicAWEModels: calc_inertia_y_rotation, principal_frame
+using LinearAlgebra
+
+@testset "calc_inertia_y_rotation" begin
+    @testset "diagonalizes a synthetic XZ-symmetric tensor" begin
+        I_tensor = [12.0 0.0 3.5;
+                    0.0  30.0 0.0;
+                    3.5  0.0  10.0]
+        I_diag, Ry = calc_inertia_y_rotation(I_tensor)
+
+        @test isapprox(I_diag[1, 3], 0.0; atol=1e-10)
+        @test isapprox(I_diag[3, 1], 0.0; atol=1e-10)
+        @test Ry * I_tensor * Ry' ≈ I_diag atol=1e-10
+
+        # Proper rotation about Y only
+        @test Ry[1, 2] == 0 && Ry[2, 1] == 0 &&
+              Ry[2, 3] == 0 && Ry[3, 2] == 0 && Ry[2, 2] == 1
+        @test Ry * Ry' ≈ I(3) atol=1e-10
+        @test isapprox(det(Ry), 1.0; atol=1e-12)
+    end
+
+    @testset "matches the closed-form axis assignment for the A1-15 wing" begin
+        # Raw (pre-diagonalization) inertia tensor of a hybrid wing,
+        # as returned by `normalized_inertia`. I_xx (271.8) and I_zz (281.2)
+        # are close enough that `principal_frame`'s eigendecomposition +
+        # permutation search picks a qualitatively different axis assignment
+        # (rotated ~90° from this one) than the closed-form solution.
+        I_cad = [271.84319281707144    0.01785249304951421  4.080525782000695;
+                   0.01785249304951421 57.3152905862639     -7.327690738960784e-5;
+                   4.080525782000695  -7.327690738960784e-5  281.23766987051357]
+
+        I_diag, Ry = calc_inertia_y_rotation(I_cad)
+        theta = rad2deg(atan(Ry[1, 3], Ry[1, 1]))
+        @test isapprox(theta, 69.5095; atol=1e-3)
+
+        # The generic permutation-search rotation is ~90° away from the
+        # closed-form one on this near-degenerate tensor.
+        _, R_gen = principal_frame(I_cad)
+        theta_gen = rad2deg(atan(R_gen[1, 3], R_gen[1, 1]))
+        angle_diff = abs(mod(theta - theta_gen + 180, 360) - 180)
+        @test isapprox(angle_diff, 90.0; atol=1.0)
+    end
+end
+nothing

--- a/test/test_inertia_y_rotation.jl
+++ b/test/test_inertia_y_rotation.jl
@@ -33,7 +33,7 @@ using LinearAlgebra
         @test isapprox(det(Ry), 1.0; atol=1e-12)
     end
 
-    @testset "matches the closed-form axis assignment for the A1-15 wing" begin
+    @testset "matches the closed-form axis assignment for a hybrid wing" begin
         # Raw (pre-diagonalization) inertia tensor of a hybrid wing,
         # as returned by `normalized_inertia`. I_xx (271.8) and I_zz (281.2)
         # are close enough that `principal_frame`'s eigendecomposition +


### PR DESCRIPTION
- [x] Allow any number of twist surfaces
- [x] Allow a different number of points for each twist surface
- [x] Use black as the color for point and segment labels in the 3D viewer, and put them in the foreground
- [x] Add torsional restoring stiffness for twist dynamics [N·m/rad]; also add it to the yaml importer
- [x] Fix bug that was introduced in the large refactoring commit
- [x] Add tests