### PR TITLE
Make pulley damping a per-pulley variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## Unreleased
+
+### Added
+- Per-pulley `damping` [1/s]: the damping of the pulley velocity is a field of
+  `Pulley` (default `DEFAULT_PULLEY_DAMPING = 5.0`, the previously hardcoded
+  value), settable per pulley with the new `set_pulley_damping(sys, damping
+  [, pulley_idxs])`, as a `damping` keyword of the `Pulley` constructor, or as
+  an optional `damping` column of the YAML `pulleys` table. It is a flattened
+  parameter re-synced from the `SystemStructure` on every step, so changing it
+  on a running model needs no rebuild. Adding the field changes the serialized
+  layout of `Pulley`, hence the patch version bump: caches keyed on the package
+  version (model binaries, and the settled structures of dependent packages)
+  miss cleanly instead of failing to deserialize.
+
 ## v0.13.0 06-08-2026
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymbolicAWEModels"
 uuid = "9c9a347c-5289-41db-a9b9-25ccc76c3360"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Bart van de Lint <bart@vandelint.net> and contributors"]
 
 [workspace]

--- a/docs/src/exported_functions.md
+++ b/docs/src/exported_functions.md
@@ -39,6 +39,7 @@ load_sys_struct_from_yaml
 ```@docs
 set_world_frame_damping
 set_body_frame_damping
+set_pulley_damping
 calc_steady_torque
 ```
 

--- a/docs/src/exported_types.md
+++ b/docs/src/exported_types.md
@@ -65,7 +65,7 @@ Segment
 Segment(name, set, point_i, point_j; l0, compression_frac, diameter_mm, unit_stiffness, unit_damping)
 Segment(name, point_i, point_j, unit_stiffness, unit_damping, diameter; l0, compression_frac)
 Pulley
-Pulley(name, segment_i, segment_j, type)
+Pulley(name, segment_i, segment_j, type; damping)
 Tether
 Tether(name, segments::AbstractVector, stretched_length; start_point, end_point, tether_force, stretch_frac)
 Tether(name, stretched_length; start_point, end_point, n_segments, unit_stiffness, unit_damping, diameter, tether_force, stretch_frac)

--- a/src/SymbolicAWEModels.jl
+++ b/src/SymbolicAWEModels.jl
@@ -84,6 +84,7 @@ export find_steady_state!
 export linearize!
 export set_world_frame_damping
 export set_body_frame_damping
+export set_pulley_damping, DEFAULT_PULLEY_DAMPING
 export segment_stretch_stats
 export calc_steady_torque
 

--- a/src/generate_system/pulley_eqs.jl
+++ b/src/generate_system/pulley_eqs.jl
@@ -9,6 +9,10 @@
 
 Generate equations for pulley dynamics (rope distribution over pulleys).
 
+The pulley velocity is damped with `pulley.damping` [1/s], a flattened parameter
+read from the live `SystemStructure` on every step, so
+[`set_pulley_damping`](@ref) takes effect without rebuilding the model.
+
 # Arguments
 - `eqs`, `defaults`: Accumulating vectors for the MTK system.
 - `pulleys`: Collection of Pulley objects.
@@ -26,7 +30,6 @@ function pulley_eqs!(eqs, defaults, pulleys, segments, params, initial;
         pulley_force(t)[eachindex(pulleys)]
         pulley_acc(t)[eachindex(pulleys)]
     end
-    @parameters pulley_damp = 5.0
 
     for pulley in pulleys
         segment = segments[pulley.segment_idxs[1]]
@@ -45,7 +48,8 @@ function pulley_eqs!(eqs, defaults, pulleys, segments, params, initial;
                 eqs
                 D(pulley_len[pulley.idx]) ~ pulley_vel[pulley.idx]
                 D(pulley_vel[pulley.idx]) ~
-                    pulley_acc[pulley.idx] - pulley_damp * pulley_vel[pulley.idx]
+                    pulley_acc[pulley.idx] -
+                    params.pulleys[pulley.idx].damping * pulley_vel[pulley.idx]
             ]
             defaults = [
                 defaults

--- a/src/system_structure/types.jl
+++ b/src/system_structure/types.jl
@@ -751,10 +751,18 @@ mutable struct Pulley
     len::SimFloat
     "Current pulley velocity [m/s] (updated during simulation)."
     vel::SimFloat
+    "Damping of the pulley velocity [1/s]; see [`set_pulley_damping`](@ref)."
+    damping::SimFloat
 end
 
 """
-    Pulley(name, segment_i, segment_j, type)
+Default damping of the pulley velocity [1/s], used when a `Pulley` is created
+without an explicit `damping`.
+"""
+const DEFAULT_PULLEY_DAMPING = 5.0
+
+"""
+    Pulley(name, segment_i, segment_j, type; damping=DEFAULT_PULLEY_DAMPING)
 
 Constructs a `Pulley` object that enforces length redistribution between two segments.
 
@@ -762,11 +770,14 @@ Constructs a `Pulley` object that enforces length redistribution between two seg
 - `name::Union{Int, Symbol}`: Name/identifier for the pulley.
 - `segment_i`, `segment_j`: References to the two segments (names or indices).
 - `type::DynamicsType`: Dynamics type (`DYNAMIC`).
+
+# Keyword arguments
+- `damping`: Damping of the pulley velocity [1/s], see [`set_pulley_damping`](@ref).
 """
-function Pulley(name, segment_i, segment_j, type)
+function Pulley(name, segment_i, segment_j, type; damping=DEFAULT_PULLEY_DAMPING)
     s1 = segment_i isa Integer ? Int(segment_i) : Symbol(segment_i)
     s2 = segment_j isa Integer ? Int(segment_j) : Symbol(segment_j)
-    return Pulley(0, name, (0, 0), (s1, s2), type, 0.0, 0.0, 0.0)
+    return Pulley(0, name, (0, 0), (s1, s2), type, 0.0, 0.0, 0.0, damping)
 end
 
 # ==================== TETHER ==================== #

--- a/src/system_structure/utilities.jl
+++ b/src/system_structure/utilities.jl
@@ -1152,6 +1152,48 @@ function set_body_frame_damping(sys::SystemStructure, damping::Union{Real, Abstr
     set_body_frame_damping(sys, damping, eachindex(sys.points))
 end
 
+"""
+    set_pulley_damping(sys::SystemStructure, damping, pulley_idxs)
+
+Set the damping of the pulley velocity for the pulleys `pulley_idxs`.
+
+Pulley damping acts on the rate at which line length is redistributed over a
+pulley: ``\\dot{v}_p = a_p - c_{damp} \\, v_p``, with `damping` the coefficient
+``c_{damp}`` [1/s]. It damps the pulley oscillation only and vanishes at
+equilibrium, so it does not change the settled geometry.
+
+The value is a field of the `SystemStructure`, flattened into an MTK parameter
+that is re-synced from it on every step — changing it on a running model takes
+effect on the next step, without rebuilding the model.
+
+# Arguments
+- `sys::SystemStructure`: The system structure to modify.
+- `damping::Real`: Damping coefficient [1/s] (default [`DEFAULT_PULLEY_DAMPING`](@ref)).
+- `pulley_idxs`: Indices of the pulleys to apply the damping to.
+
+# Returns
+- `nothing`
+"""
+function set_pulley_damping(sys::SystemStructure, damping::Real, pulley_idxs)
+    for idx in pulley_idxs
+        sys.pulleys[idx].damping = damping
+    end
+    return nothing
+end
+
+"""
+    set_pulley_damping(sys::SystemStructure, damping)
+
+Set the damping of the pulley velocity [1/s] for all pulleys of `sys`; see
+[`set_pulley_damping`](@ref).
+
+# Returns
+- `nothing`
+"""
+function set_pulley_damping(sys::SystemStructure, damping::Real)
+    set_pulley_damping(sys, damping, eachindex(sys.pulleys))
+end
+
 # ==================== SEGMENT STATISTICS ==================== #
 
 """

--- a/src/yaml_loader.jl
+++ b/src/yaml_loader.jl
@@ -734,10 +734,11 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
     if haskey(data, "pulleys")
         pulley_rows = parse_table(data["pulleys"])
         for (i, row) in enumerate(pulley_rows)
-            # Create Pulley using new constructor (name, segment_i, segment_j, type)
+            # Create Pulley using new constructor (name, segment_i, segment_j, type);
+            # the optional `damping` column falls back to DEFAULT_PULLEY_DAMPING.
             pulley = call_yaml_constructor(Pulley, row,
                 [:name, :segment_i, :segment_j, :type],
-                Vector{Union{}}();
+                [:damping];
                 mappings=Dict(
                     :segment_i => row -> yaml_to_ref(row.segment_i),
                     :segment_j => row -> yaml_to_ref(row.segment_j),

--- a/test/test_pulley.jl
+++ b/test/test_pulley.jl
@@ -257,6 +257,14 @@ system:
         pulley = sys.pulleys[:main_pulley]
         @test pulley.type == SymbolicAWEModels.DYNAMIC
 
+        # The YAML has no `damping` column, so the pulley keeps the default
+        @test pulley.damping == DEFAULT_PULLEY_DAMPING
+        set_pulley_damping(sys, 12.0)
+        @test pulley.damping == 12.0
+        set_pulley_damping(sys, DEFAULT_PULLEY_DAMPING)
+        @test Pulley(:p, :left_leg, :right_leg, SymbolicAWEModels.DYNAMIC;
+                     damping=3.0).damping == 3.0
+
         println("\n  ====== Loaded pulley system: $(length(sys.points)) points, $(length(sys.segments)) segments, $(length(sys.pulleys)) pulley ======\n")
     end
 


### PR DESCRIPTION
The damping of the pulley velocity was a hardcoded MTK parameter (`@parameters pulley_damp = 5.0`) with no way to reach it. It is now a `damping` field of `Pulley`, read in the equation as `params.pulleys[i].damping`, so it goes through the flat-parameter sync and can be changed on a running model without a rebuild.

Settable with `set_pulley_damping(sys, damping[, pulley_idxs])`, as a `damping` keyword of the `Pulley` constructor, or as an optional `damping` column of the YAML `pulleys` table. Default unchanged (5.0).

The added field changes the serialized layout of `Pulley`, so the patch version is bumped: caches keyed on the package version miss cleanly instead of failing to deserialize.