### PR TITLE
Give AeroPressure per-section inflow instead of a wing-wide mean

### DIFF
--- a/docs/src/private_functions.md
+++ b/docs/src/private_functions.md
@@ -339,6 +339,7 @@ SymbolicAWEModels.aero_section_columns
 SymbolicAWEModels.interp_strut
 SymbolicAWEModels.interp_sections
 SymbolicAWEModels.reconstruct_sections_sym
+SymbolicAWEModels.reconstruct_inflow_sym
 SymbolicAWEModels.reconstruct_sections_b
 SymbolicAWEModels.write_live_aero_log_points!
 SymbolicAWEModels.AeroHandle

--- a/src/aero_modes/common.jl
+++ b/src/aero_modes/common.jl
@@ -514,10 +514,20 @@ supports_panel_decomposition(::AbstractAeroModel) = false
 How each refined section's apparent wind and density are averaged over the wing's
 structural points. `groups[g]` is a list of `(point column, weight)` whose weights sum
 to one, and `section_group[s]` names the group refined section `s` reads. Sections
-sharing a group share the one [`AeroInflow`](@ref) that averages it, so a mode with a
-single uniform inflow builds a single averaging component rather than one per section.
+sharing a group share the one [`AeroInflow`](@ref) that averages it.
+
+The default is one group per refined section, gathered from the same bounding struts
+[`aero_geometry_entries`](@ref) reconstructs that section's corners from, so a
+section's inflow and its geometry read the same points. Overriding this with a
+wing-wide mean drops the rotational part of the velocity field — a rigid rotation
+about the point centroid averages to zero — leaving the panels without rate damping.
 """
-function aero_inflow_groups end
+function aero_inflow_groups(mode, wing, points)
+    column = aero_section_columns(wing, points)
+    sections = eachindex(section_interp_caches(mode)[1])
+    groups = [strut_inflow_weights(mode, section, column) for section in sections]
+    return groups, collect(sections)
+end
 
 """
     aero_scatter_entries(mode, wing, points) -> Vector
@@ -1117,6 +1127,29 @@ function reconstruct_sections_sym(mode, wing, points, connectors, column)
                 for s in 1:n_struts]
     left, weight, le_offset, te_offset = section_interp_caches(mode)
     return interp_sections(strut_le, strut_te, left, weight, le_offset, te_offset)
+end
+
+"""
+    reconstruct_inflow_sym(mode, wing, connectors, column) -> (sec_va, sec_rho)
+
+Live symbolic body-frame apparent wind and density of every refined section: each
+strut's LE/TE connector values averaged into one strut value, then interpolated by the
+frozen mesh weights — the same struts and weights [`reconstruct_sections_sym`](@ref)
+builds that section's corners from, so a section's inflow and its geometry read the
+same points. Shared by all continuous VSM modes.
+"""
+function reconstruct_inflow_sym(mode, wing, connectors, column)
+    n_struts = Int(wing.vsm_wing.n_unrefined_sections)
+    strut_va = [0.5 * (collect(connectors.va[:, column[(s, :LE)]]) +
+                       collect(connectors.va[:, column[(s, :TE)]]))
+                for s in 1:n_struts]
+    strut_rho = [0.5 * (connectors.rho[column[(s, :LE)]] +
+                        connectors.rho[column[(s, :TE)]])
+                 for s in 1:n_struts]
+    left, weight, _, _ = section_interp_caches(mode)
+    sec_va = [interp_strut(strut_va, left, weight, s) for s in eachindex(left)]
+    sec_rho = [interp_strut(strut_rho, left, weight, s) for s in eachindex(left)]
+    return sec_va, sec_rho
 end
 
 """

--- a/src/aero_modes/continuous.jl
+++ b/src/aero_modes/continuous.jl
@@ -201,7 +201,6 @@ function aero_component(mode::ContinuousAero, wing::ParticleWing, sys_struct;
 
     column = aero_section_columns(wing, points)
     n_panels = Int(wing.vsm_wing.n_panels)
-    n_struts = Int(wing.vsm_wing.n_unrefined_sections)
     left = mode.section_left_strut
     lweight = mode.section_left_weight
     length(left) == n_panels + 1 || error(
@@ -212,14 +211,7 @@ function aero_component(mode::ContinuousAero, wing::ParticleWing, sys_struct;
 
     sec_le, sec_te =
         reconstruct_sections_sym(mode, wing, points, connectors, column)
-    strut_va = [0.5 * (collect(connectors.va[:, column[(s, :LE)]]) +
-                       collect(connectors.va[:, column[(s, :TE)]]))
-                for s in 1:n_struts]
-    strut_rho = [0.5 * (connectors.rho[column[(s, :LE)]] +
-                        connectors.rho[column[(s, :TE)]])
-                 for s in 1:n_struts]
-    sec_va = [interp_strut(strut_va, left, lweight, s) for s in 1:(n_panels + 1)]
-    sec_rho = [interp_strut(strut_rho, left, lweight, s) for s in 1:(n_panels + 1)]
+    sec_va, sec_rho = reconstruct_inflow_sym(mode, wing, connectors, column)
 
     orient = panel_span_signs(wing, spanwise)
     eqs, panel_vars, panel_force, panel_couple = build_panel_force_eqs(
@@ -252,19 +244,6 @@ end
 # ==================== per-panel decomposition ==================== #
 
 supports_panel_decomposition(::ContinuousAero) = true
-
-"""
-    aero_inflow_groups(mode::ContinuousAero, wing, points)
-
-One group per refined section: its inflow is the strut interpolation of the bounding
-struts' LE/TE station values, which is what `aero_component` interpolates inline.
-"""
-function aero_inflow_groups(mode::ContinuousAero, wing, points)
-    column = aero_section_columns(wing, points)
-    sections = eachindex(mode.section_left_strut)
-    groups = [strut_inflow_weights(mode, section, column) for section in sections]
-    return groups, collect(sections)
-end
 
 """
     aero_scatter_entries(mode::ContinuousAero, wing, points)

--- a/src/aero_modes/pressure.jl
+++ b/src/aero_modes/pressure.jl
@@ -107,9 +107,9 @@ Live per-refined-panel VSM force (shared [`build_panel_force_eqs`](@ref) on the
 fixed loaded mesh + live apparent wind) scattered over the frozen surface traction
 pattern. Each wing node's force is `Σ over mapped (panel, node) of
 traction[node] + (panel_force[panel] − traction_net[panel]) / n_nodes`, so per panel
-the point forces sum to the live `panel_force` exactly. The apparent wind is the mean
-of the wing's structural points' body-frame apparent wind (v1 uniform inflow); `v_ind`,
-`traction`, `traction_net` and the `cl/cd/cm` polars are flat params refreshed every
+the point forces sum to the live `panel_force` exactly. Apparent wind and density are
+per refined section ([`reconstruct_inflow_sym`](@ref)); `v_ind`, `traction`,
+`traction_net` and the `cl/cd/cm` polars are flat params refreshed every
 `vsm_interval`.
 """
 function aero_component(mode::AeroPressure, wing::ParticleWing, sys_struct;
@@ -141,13 +141,7 @@ function aero_component(mode::AeroPressure, wing::ParticleWing, sys_struct;
     sec_le, sec_te =
         reconstruct_sections_sym(mode, wing, points, connectors, column)
 
-    # Live wing-level apparent wind & density: mean over the wing's structural points (v1
-    # uniform inflow).
-    va_wing = [sum(connectors.va[c, k] for k in 1:num_points) / num_points
-               for c in 1:3]
-    rho_wing = sum(connectors.rho[k] for k in 1:num_points) / num_points
-    sec_va = [va_wing for _ in 1:(n_panels + 1)]
-    sec_rho = [rho_wing for _ in 1:(n_panels + 1)]
+    sec_va, sec_rho = reconstruct_inflow_sym(mode, wing, connectors, column)
 
     spanwise = collect(SimFloat, wing.vsm_wing.spanwise_direction)
     scale = 1.0 + (isfinite(wing.aero_scale_chord) ?
@@ -554,19 +548,6 @@ zero_aero_force() = zeros(SimFloat, 3)
 # ==================== per-panel decomposition ==================== #
 
 supports_panel_decomposition(::AeroPressure) = true
-
-"""
-    aero_inflow_groups(mode::AeroPressure, wing, points)
-
-One group for the whole wing: under the v1 uniform-inflow assumption every refined
-section reads the same mean over the wing's structural points, so one
-[`AeroInflow`](@ref) averages it and every panel reads that.
-"""
-function aero_inflow_groups(mode::AeroPressure, wing, points)
-    share = SimFloat(1 / length(points))
-    group = [(k, share) for k in eachindex(points)]
-    return [group], ones(Int, length(mode.section_left_strut))
-end
 
 """
     aero_scatter_entries(mode::AeroPressure, wing, points)

--- a/test/test_pressure_aero.jl
+++ b/test/test_pressure_aero.jl
@@ -20,7 +20,8 @@ end
 
 using Test
 using SymbolicAWEModels
-using SymbolicAWEModels: VortexStepMethod, refresh_particle_aero!, SimFloat
+using SymbolicAWEModels: VortexStepMethod, refresh_particle_aero!, SimFloat,
+                         aero_inflow_groups, wing_points
 using KiteUtils
 using LinearAlgebra
 
@@ -57,6 +58,14 @@ end
         @test all(idx -> idx in [p.idx for p in wing_pts],
                   reduce(vcat, mode.station_point))
         @test all(p.section_aero !== nothing for p in wing.vsm_aero.panels)
+    end
+
+    @testset "per-section inflow groups" begin
+        groups, section_group = aero_inflow_groups(mode, wing, wing_points(sys, wing))
+        @test length(groups) == length(mode.section_left_strut)
+        @test length(unique(section_group)) == length(groups)
+        @test length(unique(groups)) > 1
+        @test all(g -> isapprox(sum(last, g), 1.0; atol=1e-10), groups)
     end
 
     @testset "frame guard rejects misalignment" begin


### PR DESCRIPTION
## The bug

`AeroPressure` replaced every refined section's apparent wind and density with the **mean over all of the wing's structural points**, in both build paths:

- `aero_inflow_groups(::AeroPressure, …)` returned a single group covering the whole wing, with every section pointing at it (kernel/scheduled backend).
- `aero_component(::AeroPressure, ::ParticleWing, …)` built `va_wing`/`rho_wing` means and replicated them across all `n_panels + 1` sections (monolith).

A rigid rotation of the point cloud about its centroid has **exactly zero** mean point velocity, so that average annihilates the entire rotational part of the velocity field. Between VSM refreshes no rate damping reached the panels, and none appeared in the Jacobian the BDF solver builds. Damping was only reintroduced in discrete jumps at each refresh, where the VSM solve does see `ω_b` via `set_va!`.

Panel *geometry* was always live and per-panel — the corners come from real structural points — so panels saw different chords against the same wind vector. Only the velocity field was uniform.

## Why it was there

Nothing about the mode required it. `section_interp_caches`, `strut_inflow_weights` and `aero_geometry_entries` are all generic on the mode and read only `section_left_strut` / `section_left_weight`, which `AeroPressure` carries. Its *geometry* already used the shared strut interpolation via the mode-independent `aero_geometry_entries`.

This looks like a leftover: when AeroPressure was migrated to deform like ContinuousAero (coarsen onto struts, shared reconstruct helpers), the geometry moved onto the shared helpers and the inflow stub stayed at v1. `ContinuousAero` had it right in both paths all along.

## The change

- `aero_inflow_groups` becomes the **generic** strut-interpolated implementation in `common.jl`; both mode-specific methods are deleted. Modes wanting a wing-wide mean now opt in explicitly.
- `reconstruct_inflow_sym` extracts the symbolic strut-average-then-interpolate that `aero_component(::ContinuousAero)` hand-rolled, so both modes share it — the same struts and weights `reconstruct_sections_sym` builds the section's corners from.

Net: 52 insertions, 49 deletions, one duplicated implementation removed.

## Why it survived

`AeroPressure` has no parity or damping test. Its "correct total force" test **cannot** see a distribution error: `point_offset` is zero-sum per panel by construction, so the panel total is exact no matter how wrong the per-section inflow is. `ContinuousAero` has both "solve-point parity with full VSM" and "aerodynamic damping (live forces, frozen circulation)"; neither was ever mirrored.

This PR adds a cheap structural guard (`per-section inflow groups`) pinning the grouping. **The dynamic parity/damping tests for AeroPressure are still missing** and should follow.

## ⚠️ Delete cached models before testing

The generated wiring changes but **no field in `aero_hash_id` does**, so cached `model_*.bin` files hit and silently reuse the old physics. Delete them, or you will measure no difference.

Follow-up worth doing: fold a codegen version constant into the hash so this class of stale-cache trap disappears.

## Testing

`test_continuous_aero.jl` + `test_pressure_aero.jl`: **46/46 pass** (including the 4 new assertions). The broader `test_aero_modes.jl` / `test_flap_aero.jl` sweep was still running locally when this was opened — relying on CI for the full suite.

## Related findings (not addressed here)

Investigating this turned up several neighbouring issues, none fixed in this PR:

1. Monolith and decomposition are duplicate implementations of the same physics with **no test asserting they agree** — this is what let the divergence survive. I verified the scatter weights match by hand today.
2. `frame_tol_frac` is checked once at build and never again, on a model whose purpose is that the structure deforms.
3. No runtime force/moment conservation diagnostic; the check exists only in `test_wing.jl`.
4. `AeroPressure`'s `point_offset` is stored in newtons at the refresh-time `q` and does not rescale with live dynamic pressure between refreshes — panel totals stay exact, the chordwise distribution drifts.
5. VSM refresh cadence is a step counter with no trust region on the `AeroLinearized` Taylor expansion; nothing bounds how far the state strays from the operating point.
6. `sim!` defaults `vsm_interval=3`, `next_step!` defaults `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)