### PR TITLE
Control a segment's damping and a tether's compression behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@
   no force at all, at the cost of a force step of
   `unit_damping / l0 · spring_vel` at the crossing. Also readable as a
   `segments` YAML column.
+- `Tether(...; compression_frac, compression_damping_frac)` hands both to every
+  segment a Route 2 tether generates, so an auto-generated line is no longer
+  stuck at the `Segment` default of `compression_frac = 0.1`. Also readable as
+  `tethers` YAML columns. A tether without a winch holds its length fixed, so
+  this is the way to split one line into several segments without writing every
+  segment and intermediate point out by hand.
 - A `SysLog` now carries the whole differential state, so a simulation can be
   restarted from any logged step. `update_sys_state!` writes point velocities,
   per-frame body turn rates, twist_surface twist and rate, and pulley length and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@
   reloaded. Saving state alone has no such boundary.
 
 ### Added
+- `Segment(...; compression_damping_frac)` scales the damping term of a segment
+  the way `compression_frac` scales the stiffness, live in the right-hand side.
+  The default `1.0` is the previous behaviour, where damping is unaffected by
+  compression and the force is continuous at `len == l0`, but the damping ratio
+  jumps by `1/sqrt(compression_frac)` as the segment goes slack. Setting it equal
+  to `compression_frac` gives one damping ratio on both branches, and
+  `compression_damping_frac = compression_frac = 0` makes a slack segment carry
+  no force at all, at the cost of a force step of
+  `unit_damping / l0 · spring_vel` at the crossing. Also readable as a
+  `segments` YAML column.
 - A `SysLog` now carries the whole differential state, so a simulation can be
   restarted from any logged step. `update_sys_state!` writes point velocities,
   per-frame body turn rates, twist_surface twist and rate, and pulley length and

--- a/docs/src/exported_types.md
+++ b/docs/src/exported_types.md
@@ -79,7 +79,7 @@ Pulley
 Pulley(name, segment_i, segment_j, type; efficiency, damping, brake, friction_epsilon)
 Tether
 Tether(name, segments::AbstractVector, stretched_length; start_point, end_point, tether_force, stretch_frac)
-Tether(name, stretched_length; start_point, end_point, n_segments, unit_stiffness, unit_damping, diameter, tether_force, stretch_frac)
+Tether(name, stretched_length; start_point, end_point, n_segments, unit_stiffness, unit_damping, diameter, compression_frac, compression_damping_frac, tether_force, stretch_frac)
 Winch
 Winch(name, set::Settings, tethers; winch_point, init_vel, brake)
 Winch(name, tethers, gear_ratio, drum_radius, coulomb_friction, viscous_coefficient, inertia_total; winch_point, init_vel, brake)

--- a/docs/src/exported_types.md
+++ b/docs/src/exported_types.md
@@ -73,8 +73,8 @@ Point(name, pos_cad, type; wing, transform, extra_mass, body_frame_damping, worl
 TwistSurface
 TwistSurface(name, points, type, moment_frac; damping=50.0)
 Segment
-Segment(name, set, point_i, point_j; l0, compression_frac, diameter_mm, unit_stiffness, unit_damping, density, youngs_modulus, damping_per_stiffness)
-Segment(name, point_i, point_j, unit_stiffness, unit_damping, diameter; l0, compression_frac)
+Segment(name, set, point_i, point_j; l0, compression_frac, compression_damping_frac, diameter_mm, unit_stiffness, unit_damping, density, youngs_modulus, damping_per_stiffness)
+Segment(name, point_i, point_j, unit_stiffness, unit_damping, diameter; l0, compression_frac, compression_damping_frac)
 Pulley
 Pulley(name, segment_i, segment_j, type; efficiency, damping, brake, friction_epsilon)
 Tether

--- a/docs/src/private_functions.md
+++ b/docs/src/private_functions.md
@@ -185,6 +185,7 @@ SymbolicAWEModels.yaml_block_empty
 SymbolicAWEModels.yaml_vec3
 SymbolicAWEModels.yaml_matrix3
 SymbolicAWEModels.yaml_ref_field
+SymbolicAWEModels.yaml_unset
 SymbolicAWEModels.yaml_field
 SymbolicAWEModels.yaml_float_or_nan
 SymbolicAWEModels.load_yaml_bodies

--- a/docs/src/private_functions.md
+++ b/docs/src/private_functions.md
@@ -185,6 +185,7 @@ SymbolicAWEModels.yaml_block_empty
 SymbolicAWEModels.yaml_vec3
 SymbolicAWEModels.yaml_matrix3
 SymbolicAWEModels.yaml_ref_field
+SymbolicAWEModels.yaml_field
 SymbolicAWEModels.yaml_float_or_nan
 SymbolicAWEModels.load_yaml_bodies
 SymbolicAWEModels.load_yaml_joints

--- a/docs/src/tutorial_yaml.md
+++ b/docs/src/tutorial_yaml.md
@@ -297,6 +297,19 @@ tethers:
     - [main, kite, ground, 5]
 ```
 
+The generated points are `DYNAMIC` and the generated segments take the tether's
+material columns, which are the [Segments](#Segments) ones (`diameter_mm`,
+`unit_stiffness`, `unit_damping`, `youngs_modulus`, `damping_per_stiffness`,
+`density`, `compression_frac`, `compression_damping_frac`) and may equally come
+from a multi-variable. A tether without a winch keeps its length fixed, which is
+how a plain line is split into several segments.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `init_stretched_length` | Float/nothing | Placed (stretched) standoff [m]; `reinit!` moves the free end to span it. `nothing` = keep the point geometry |
+| `init_tether_force` | Float/nothing | Target initial spring force [N], default 0 |
+| `init_stretch_frac` | Float/nothing | Initial unstretched/stretched ratio; 1.0 is untensioned, `> 1` slack. Excludes `init_tether_force` |
+
 ### Winches
 
 ```yaml

--- a/docs/src/tutorial_yaml.md
+++ b/docs/src/tutorial_yaml.md
@@ -257,6 +257,7 @@ The material columns can also come from a multi-variable, see
 | `youngs_modulus` | Float/nothing | Diameter-independent alternative to `unit_stiffness` [Pa] |
 | `damping_per_stiffness` | Float/nothing | Diameter-independent alternative to `unit_damping` [s] |
 | `compression_frac` | Float | Compressive/tensile stiffness ratio (0-1) |
+| `compression_damping_frac` | Float | Fraction of `unit_damping` still acting under compression (0-1, default 1) |
 | `density` | Float/nothing | Material density [kg/m³]; falls back to `set.rho_tether` |
 
 ### Pulleys

--- a/src/components/components.jl
+++ b/src/components/components.jl
@@ -142,7 +142,9 @@ function segment_spring_params(params, idx; with_drag = true)
     wind_gnd = ground_wind_vec(params)
     nonlinear = !(params.reg.sys_struct.segments[idx].unit_stiffness isa Real)
     spring = (; unit_stiffness = seg.unit_stiffness, unit_damping = seg.unit_damping,
-              compression_frac = seg.compression_frac, diameter = seg.diameter,
+              compression_frac = seg.compression_frac,
+              compression_damping_frac = seg.compression_damping_frac,
+              diameter = seg.diameter,
               density = seg.density, cd_tether, nonlinear)
     wind_factor = param_computed!(params.reg, :wind_factor, WindFactorReader())
     return spring, wind_gnd, wind_factor
@@ -150,9 +152,9 @@ end
 
 """
     segment_load_terms(s, src_pos, src_vel, dst_pos, dst_vel, unit_stiffness,
-                       unit_damping, compression_frac, l0, diameter, density,
-                       cd_tether, wind_gnd, wind_factor; with_drag=true,
-                       nonlinear=false)
+                       unit_damping, compression_frac, compression_damping_frac,
+                       l0, diameter, density, cd_tether, wind_gnd, wind_factor;
+                       with_drag=true, nonlinear=false)
 
 Every load term a segment produces, as a named tuple: the geometry (`len`,
 `unit_vec`), the signed scalar spring-damper tension `spring` and its vector
@@ -165,6 +167,7 @@ are unused.
 """
 function segment_load_terms(s, src_pos, src_vel, dst_pos, dst_vel,
                             unit_stiffness, unit_damping, compression_frac,
+                            compression_damping_frac,
                             l0, diameter, density, cd_tether, wind_gnd, wind_factor;
                             with_drag = true, nonlinear = false)
     _, len, unit_vec, spring_vel =
@@ -172,7 +175,7 @@ function segment_load_terms(s, src_pos, src_vel, dst_pos, dst_vel,
     spring = nonlinear ?
         segment_nonlinear_force(len, l0, spring_vel, unit_stiffness, unit_damping) :
         segment_spring_force(len, l0, spring_vel, unit_stiffness, unit_damping,
-                             compression_frac)
+                             compression_frac, compression_damping_frac)
     spring_vec = spring .* unit_vec
     half_mass = segment_half_mass(l0, diameter, density)
     half_drag = zeros(Num, 3)
@@ -791,7 +794,8 @@ function segment_eqs(s, params, idx, io, rest_len; with_drag = true)
     spring, wind, wind_factor = segment_spring_params(params, idx; with_drag)
     loads = segment_load_terms(s, collect(io.src_pos), collect(io.src_vel),
         collect(io.dst_pos), collect(io.dst_vel), spring.unit_stiffness,
-        spring.unit_damping, spring.compression_frac, rest_len, spring.diameter,
+        spring.unit_damping, spring.compression_frac,
+        spring.compression_damping_frac, rest_len, spring.diameter,
         spring.density, spring.cd_tether, collect(wind), wind_factor;
         with_drag, nonlinear = spring.nonlinear)
     eqs = [

--- a/src/components/kernels.jl
+++ b/src/components/kernels.jl
@@ -25,21 +25,31 @@ end
 
 """
     segment_spring_force(len, l0, spring_vel, unit_stiffness, unit_damping,
-                         compression_frac)
+                         compression_frac, compression_damping_frac=1.0)
 
 Scalar spring-damper force along a segment (the Real-`unit_stiffness` branch of
 `segment_eqs!`). Stiffness is `unit_stiffness / len` in tension and softens to
 `compression_frac` of that under compression; the damping term
-`(unit_damping / len) · spring_vel` opposes the closing speed and is deliberately
-left out of that softening. Softening it would make the force jump at `len == l0`,
-where the stiffness term crosses continuously only because `len - l0` vanishes
-there; a taut tether sits on that crossing, so the jump diverges the solver.
+`(unit_damping / len) · spring_vel` opposes the closing speed and softens to
+`compression_damping_frac` of itself over the same branch.
+
+With the default `compression_damping_frac = 1.0` the damping is unaffected, so the
+force is continuous at `len == l0` (the stiffness term crosses there only because
+`len - l0` vanishes), but the damping ratio jumps by `1/sqrt(compression_frac)` as a
+segment goes slack. Setting `compression_damping_frac = compression_frac` keeps one
+damping ratio on both branches instead, and `0.0` with `compression_frac = 0.0`
+makes a slack segment carry no force at all — at the cost of a force step of
+`(1 - compression_damping_frac) · unit_damping / l0 · spring_vel` at the crossing,
+which a taut tether sits on.
+
 Multiply by the segment `unit_vec` for the force vector on the source endpoint.
 """
 function segment_spring_force(len, l0, spring_vel, unit_stiffness, unit_damping,
-                              compression_frac)
-    damping = unit_damping / len
-    stiffness = ifelse(len > l0, unit_stiffness / len,
+                              compression_frac, compression_damping_frac=1.0)
+    taut = len > l0
+    damping = ifelse(taut, unit_damping,
+                     compression_damping_frac * unit_damping) / len
+    stiffness = ifelse(taut, unit_stiffness / len,
                        compression_frac * unit_stiffness / len)
     return stiffness * (len - l0) - damping * spring_vel
 end

--- a/src/generate_system/segment_eqs.jl
+++ b/src/generate_system/segment_eqs.jl
@@ -137,11 +137,14 @@ function segment_eqs!(s, eqs, points, segments,
             ]
         else
             idx = segment.idx
-            damp_eq = damping[idx] ~
-                params.segments[idx].unit_damping / len[idx]
+            unit_damp = params.segments[idx].unit_damping
             if segment.unit_stiffness isa Real
                 k = params.segments[idx].unit_stiffness
                 stiff_eqs = [
+                    damping[idx] ~ ifelse(
+                        len[idx] > l0[idx], unit_damp,
+                        params.segments[idx].compression_damping_frac *
+                            unit_damp) / len[idx]
                     stiffness[idx] ~ ifelse(
                         len[idx] > l0[idx], k / len[idx],
                         params.segments[idx].compression_frac * k / len[idx])
@@ -154,6 +157,7 @@ function segment_eqs!(s, eqs, points, segments,
                 force_law = params.segments[idx].unit_stiffness
                 strain = (len[idx] - l0[idx]) / l0[idx]
                 stiff_eqs = [
+                    damping[idx] ~ unit_damp / len[idx]
                     stiffness[idx] ~ 0.0
                     spring_force[idx] ~ force_law(strain) -
                         damping[idx] * spring_vel[idx]
@@ -161,7 +165,6 @@ function segment_eqs!(s, eqs, points, segments,
             end
             eqs = [
                 eqs
-                damp_eq
                 stiff_eqs
                 spring_force_vec[:, idx] ~ spring_force[idx] * unit_vec[:, idx]
             ]

--- a/src/system_structure/system_structure_core.jl
+++ b/src/system_structure/system_structure_core.jl
@@ -284,7 +284,9 @@ end
     expand_auto_tethers!(points, segments, tethers, set)
 
 For Route 2 tethers (auto-generation), create intermediate DYNAMIC
-points and segments. Must be called before `assign_indices_and_resolve!`.
+points and segments, each carrying the tether's material and its
+`compression_frac`/`compression_damping_frac`. Must be called before
+`assign_indices_and_resolve!`.
 
 Detects Route 2 tethers by checking `start_point_ref !== nothing`
 and `segment_refs` names not yet present in `segments`.
@@ -404,7 +406,9 @@ function expand_auto_tethers!(
             push!(segments, Segment(
                 seg_sym, start_ref, end_ref,
                 unit_stiffness, unit_damping, diameter;
-                l0=seg_l0, density))
+                l0=seg_l0, density,
+                compression_frac=tether.compression_frac,
+                compression_damping_frac=tether.compression_damping_frac))
             push!(seg_names, seg_sym)
         end
     end

--- a/src/system_structure/types.jl
+++ b/src/system_structure/types.jl
@@ -877,6 +877,10 @@ strain returning force [N]; a callable propagates to every auto-generated segmen
 `unit_stiffness` is typed `Any` (not a type parameter) to keep `Tether` concrete,
 since `SystemStructure.tethers` is read every step.
 
+The material fields (`unit_stiffness` through `compression_damping_frac`) describe
+the segments Route 2 generates; a Route 1 tether reads them off its own segments and
+leaves these at their defaults.
+
 # Initial length
 Two distinct lengths, set independently at `reinit!`:
 - `init_stretched_len` — the *placed* (stretched) standoff; `reinit!` scales the
@@ -924,6 +928,10 @@ mutable struct Tether
     const youngs_modulus::SimFloat
     "Damping per unit stiffness [s]. Diameter-independent form of `unit_damping`."
     const damping_per_stiffness::SimFloat
+    "Compressive/tensile stiffness ratio (0-1) given to every generated segment."
+    const compression_frac::SimFloat
+    "Fraction of `unit_damping` still acting under compression (0-1), per segment."
+    const compression_damping_frac::SimFloat
     "Current stretched length [m] (updated during simulation)."
     stretched_len::SimFloat
     """Unstretched tether length [m] (sum of segment l0).
@@ -996,7 +1004,7 @@ function Tether(name, segments::AbstractVector, stretched_length=nothing;
     return Tether(0, name, Int64[], segment_refs,
                   0, name_ref(start_point), 0, name_ref(end_point),
                   length(segments),
-                  NaN, NaN, NaN, NaN, NaN, NaN, 0.0,
+                  NaN, NaN, NaN, NaN, NaN, NaN, 0.1, 1.0, 0.0,
                   0.0, init_stretched, init_force, init_frac)
 end
 
@@ -1020,8 +1028,9 @@ end
 """
     Tether(name, stretched_length=nothing;
            start_point, end_point, n_segments,
-           unit_stiffness=NaN, unit_damping=NaN,
-           diameter=NaN, tether_force=nothing, stretch_frac=nothing)
+           unit_stiffness=NaN, unit_damping=NaN, diameter=NaN,
+           compression_frac=0.1, compression_damping_frac=1.0,
+           tether_force=nothing, stretch_frac=nothing)
 
 Route 2: Construct a `Tether` for auto-generation of intermediate
 points and segments by `expand_auto_tethers!`.
@@ -1048,6 +1057,10 @@ points and segments by `expand_auto_tethers!`.
   `unit_stiffness` [Pa]. See [`resolve_material`](@ref).
 - `damping_per_stiffness::Float64=NaN`: Diameter-independent alternative
   to `unit_damping` [s].
+- `compression_frac::Float64=0.1`: Compressive/tensile stiffness ratio
+  (0-1) of every generated segment. See [`Segment`](@ref).
+- `compression_damping_frac::Float64=1.0`: Fraction of `unit_damping`
+  still acting under compression (0-1). See [`Segment`](@ref).
 - `tether_force=nothing`: Target initial spring force [N], default 0.
 - `stretch_frac=nothing`: Initial `len/stretched` fraction. Mutually
   exclusive with `tether_force`.
@@ -1056,7 +1069,8 @@ function Tether(name, stretched_length=nothing;
                 start_point, end_point, n_segments,
                 unit_stiffness=NaN, unit_damping=NaN,
                 diameter=NaN, density=NaN, youngs_modulus=NaN,
-                damping_per_stiffness=NaN, tether_force=nothing,
+                damping_per_stiffness=NaN, compression_frac=0.1,
+                compression_damping_frac=1.0, tether_force=nothing,
                 stretch_frac=nothing)
     init_force, init_frac =
         resolve_tether_init(name, tether_force, stretch_frac)
@@ -1072,7 +1086,9 @@ function Tether(name, stretched_length=nothing;
                   Float64(unit_damping),
                   Float64(diameter), Float64(density),
                   Float64(youngs_modulus),
-                  Float64(damping_per_stiffness), 0.0,
+                  Float64(damping_per_stiffness),
+                  Float64(compression_frac),
+                  Float64(compression_damping_frac), 0.0,
                   0.0, init_stretched, init_force, init_frac)
 end
 

--- a/src/system_structure/types.jl
+++ b/src/system_structure/types.jl
@@ -605,9 +605,12 @@ mutable struct Segment
     unit_damping::SimFloat
     "Rest (unstretched) length [m]."
     l0::SimFloat
-    "Compressive/tensile stiffness ratio (0-1) under compression; damping is not
-    scaled with it. 0 = a slack segment carries no spring force."
+    "Compressive/tensile stiffness ratio (0-1) under compression.
+    0 = a slack segment carries no spring force."
     compression_frac::SimFloat
+    "Fraction of `unit_damping` that still acts under compression (0-1).
+    1 = damping is unaffected by compression; 0 = a slack segment is undamped."
+    compression_damping_frac::SimFloat
     "Segment diameter [m]."
     diameter::SimFloat
     "Material density [kg/m³]."
@@ -619,7 +622,7 @@ mutable struct Segment
 end
 
 """
-    Segment(name, point_i, point_j, unit_stiffness, unit_damping, diameter; l0, compression_frac)
+    Segment(name, point_i, point_j, unit_stiffness, unit_damping, diameter; l0, compression_frac, compression_damping_frac)
 
 Basic constructor for a `Segment` object.
 
@@ -631,19 +634,23 @@ Basic constructor for a `Segment` object.
 - `diameter`: Segment diameter [m].
 
 # Keyword Arguments
-- `compression_frac::SimFloat=0.1`: Compressive/tensile stiffness ratio (0-1);
-  damping is not scaled with it. 0 = a slack segment carries no spring force.
+- `compression_frac::SimFloat=0.1`: Compressive/tensile stiffness ratio (0-1).
+  0 = a slack segment carries no spring force.
+- `compression_damping_frac::SimFloat=1.0`: Fraction of `unit_damping` still
+  acting under compression (0-1). See [`segment_spring_force`](@ref).
 - `density::SimFloat=NaN`: Material density [kg/m³] used for mass.
 """
 function Segment(name, point_i, point_j, unit_stiffness, unit_damping, diameter;
-    l0=zero(SimFloat), compression_frac=0.1, density=NaN
+    l0=zero(SimFloat), compression_frac=0.1, compression_damping_frac=1.0,
+    density=NaN
 )
     p1 = point_i isa Integer ? Int(point_i) : Symbol(point_i)
     p2 = point_j isa Integer ? Int(point_j) : Symbol(point_j)
     # Real → SimFloat; a callable force law F(ε) is kept as-is.
     stiff = unit_stiffness isa Real ? SimFloat(unit_stiffness) : unit_stiffness
     Segment(0, name, (0, 0), (p1, p2), stiff, SimFloat(unit_damping), l0,
-        compression_frac, diameter, SimFloat(density), zero(SimFloat), zero(SimFloat))
+        compression_frac, compression_damping_frac, diameter, SimFloat(density),
+        zero(SimFloat), zero(SimFloat))
 end
 
 """
@@ -713,9 +720,9 @@ function resolve_material(label, set; diameter_m=NaN, unit_stiffness=NaN,
 end
 
 """
-    Segment(name, set, point_i, point_j; l0, compression_frac, diameter_mm,
-            unit_stiffness, unit_damping, density, youngs_modulus,
-            damping_per_stiffness)
+    Segment(name, set, point_i, point_j; l0, compression_frac,
+            compression_damping_frac, diameter_mm, unit_stiffness, unit_damping,
+            density, youngs_modulus, damping_per_stiffness)
 
 Constructs a `Segment` using settings for material properties.
 
@@ -728,8 +735,10 @@ Constructs a `Segment` using settings for material properties.
 # Keyword Arguments
 - `l0::SimFloat=zero(SimFloat)`: Unstretched length [m].
   Calculated from point positions if zero.
-- `compression_frac::SimFloat=0.1`: Compressive/tensile stiffness ratio (0-1);
-  damping is not scaled with it. 0 = a slack segment carries no spring force.
+- `compression_frac::SimFloat=0.1`: Compressive/tensile stiffness ratio (0-1).
+  0 = a slack segment carries no spring force.
+- `compression_damping_frac::SimFloat=1.0`: Fraction of `unit_damping` still
+  acting under compression (0-1). See [`segment_spring_force`](@ref).
 - `diameter_mm::Float64=NaN`: Tether diameter [mm]. If `NaN`,
   uses `set.d_tether`.
 - `unit_stiffness::Float64=NaN`: Stiffness per unit length [N].
@@ -744,7 +753,7 @@ Constructs a `Segment` using settings for material properties.
   to `unit_damping` [s].
 """
 function Segment(name, set, point_i, point_j;
-    l0=zero(SimFloat), compression_frac=0.1,
+    l0=zero(SimFloat), compression_frac=0.1, compression_damping_frac=1.0,
     diameter_mm=NaN, unit_stiffness=NaN,
     unit_damping=NaN, density=NaN, youngs_modulus=NaN,
     damping_per_stiffness=NaN
@@ -760,7 +769,7 @@ function Segment(name, set, point_i, point_j;
 
     Segment(0, name, (0, 0), (p1, p2),
         unit_stiffness, unit_damping, l0,
-        compression_frac, diameter_m, density,
+        compression_frac, compression_damping_frac, diameter_m, density,
         zero(SimFloat), zero(SimFloat))
 end
 

--- a/src/yaml_loader.jl
+++ b/src/yaml_loader.jl
@@ -923,12 +923,17 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                 youngs_modulus = yaml_float_or_nan(row, :youngs_modulus)
                 damping_per_stiffness =
                     yaml_float_or_nan(row, :damping_per_stiffness)
+                compression_frac =
+                    something(yaml_float(row, :compression_frac), 0.1)
+                compression_damping_frac =
+                    something(yaml_float(row, :compression_damping_frac), 1.0)
                 tether = Tether(tether_name, stretched_length;
                     start_point=start_ref, end_point=end_ref,
                     n_segments,
                     unit_stiffness, unit_damping,
                     diameter, density, youngs_modulus,
-                    damping_per_stiffness, tether_force, stretch_frac)
+                    damping_per_stiffness, compression_frac,
+                    compression_damping_frac, tether_force, stretch_frac)
             end
             saved_len = yaml_float(row, :len)
             isnothing(saved_len) || (tether.len = SimFloat(saved_len))

--- a/src/yaml_loader.jl
+++ b/src/yaml_loader.jl
@@ -484,9 +484,17 @@ function parse_tether_init(row, tether_name)
     return stretched_length, tether_force, stretch_frac
 end
 
+"""
+    yaml_field(row, field)
+
+Optional row field, `nothing` when the column is absent or holds the `nothing`
+placeholder a written table uses for an unset cell in a column other rows fill.
+"""
 function yaml_field(row, field)
     hasfield(typeof(row), field) || return nothing
-    getfield(row, field)
+    value = getfield(row, field)
+    (value == "nothing" || value === :nothing) && return nothing
+    return value
 end
 
 function yaml_float(row, field)

--- a/src/yaml_loader.jl
+++ b/src/yaml_loader.jl
@@ -23,7 +23,7 @@ get_field_or_nothing(Tuple{Int64,Int64}, row, :pair)
 """
 function get_field_or_nothing(::Type{T}, row::NamedTuple,
                                field::Symbol) where T
-    if !haskey(row, field) || isnothing(row[field])
+    if !haskey(row, field) || yaml_unset(row[field])
         return nothing
     end
     return convert_to_type(T, row[field])
@@ -337,10 +337,7 @@ function call_yaml_constructor(
             kwargs[kwarg_name] = mappings[kwarg_name](row)
         elseif haskey(row, kwarg_name)
             val = row[kwarg_name]
-            # Skip nothing values (Julia nothing or YAML "nothing" string)
-            if !isnothing(val) && val != "nothing"
-                kwargs[kwarg_name] = val
-            end
+            yaml_unset(val) || (kwargs[kwarg_name] = val)
         end
     end
 
@@ -485,16 +482,22 @@ function parse_tether_init(row, tether_name)
 end
 
 """
+    yaml_unset(value) -> Bool
+
+Whether a cell is unset: `nothing`, or the `nothing` placeholder a written table
+uses to leave one row's cell empty in a column the other rows fill.
+"""
+yaml_unset(value) = isnothing(value) || value == "nothing" || value === :nothing
+
+"""
     yaml_field(row, field)
 
-Optional row field, `nothing` when the column is absent or holds the `nothing`
-placeholder a written table uses for an unset cell in a column other rows fill.
+Optional row field, `nothing` when the column is absent or [`yaml_unset`](@ref).
 """
 function yaml_field(row, field)
     hasfield(typeof(row), field) || return nothing
     value = getfield(row, field)
-    (value == "nothing" || value === :nothing) && return nothing
-    return value
+    return yaml_unset(value) ? nothing : value
 end
 
 function yaml_float(row, field)
@@ -708,14 +711,12 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
 
     # Helper to convert raw reference to proper type (Int or Symbol).
     yaml_to_ref = function (val)
-        isnothing(val) && return nothing
+        yaml_unset(val) && return nothing
         if val isa Integer
             return Int(val)
         elseif val isa String
-            val == "nothing" && return nothing
             return Symbol(val)
         elseif val isa Symbol
-            val === :nothing && return nothing
             return val
         else
             return Int(val)

--- a/src/yaml_loader.jl
+++ b/src/yaml_loader.jl
@@ -811,7 +811,8 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
                 Segment, row,
                 [:name, :set, :point_i, :point_j],
                 [:l0, :diameter_mm, :unit_stiffness,
-                 :unit_damping, :compression_frac, :density,
+                 :unit_damping, :compression_frac,
+                 :compression_damping_frac, :density,
                  :youngs_modulus, :damping_per_stiffness];
                 mappings=Dict(
                     :set => row -> resolved_set,

--- a/test/test_segment.jl
+++ b/test/test_segment.jl
@@ -278,7 +278,7 @@ system:
         println("\n  ====== Loaded segment: l0=$(segment.l0)m, unit_stiffness=$(segment.unit_stiffness)N, unit_damping=$(segment.unit_damping)N·s ======\n")
     end
 
-    @testset "Compression softens stiffness but not damping" begin
+    @testset "Compression softens stiffness, and damping on request" begin
         l0, unit_stiffness, unit_damping, compression_frac = 10.0, 1000.0, 10.0, 0.1
         force(len, spring_vel) = SymbolicAWEModels.segment_spring_force(
             len, l0, spring_vel, unit_stiffness, unit_damping, compression_frac)
@@ -291,7 +291,7 @@ system:
         @test damping_of(10.5) ≈ unit_damping
         @test damping_of(9.5) ≈ unit_damping
 
-        # Softening damping too would jump the force here and diverge the solver.
+        # The default leaves damping unsoftened, so the force is continuous at l0.
         step = abs(force(nextfloat(l0), 1.0) - force(prevfloat(l0), 1.0))
         @test step < 1e-9
         @test force(l0, 1.0) ≈ -unit_damping / l0
@@ -301,6 +301,19 @@ system:
             len, l0, spring_vel, unit_stiffness, unit_damping, 0.0)
         @test slack_free(9.5, 0.0) == 0.0
         @test slack_free(9.5, 1.0) ≈ -unit_damping / 9.5
+
+        # compression_damping_frac softens the damper over the same branch.
+        half(len, spring_vel) = SymbolicAWEModels.segment_spring_force(
+            len, l0, spring_vel, unit_stiffness, unit_damping,
+            compression_frac, 0.5)
+        @test (half(10.5, 0.0) - half(10.5, 1.0)) * 10.5 ≈ unit_damping
+        @test (half(9.5, 0.0) - half(9.5, 1.0)) * 9.5 ≈ 0.5unit_damping
+
+        # Both fracs 0 → a slack segment carries no force at all.
+        dead(len, spring_vel) = SymbolicAWEModels.segment_spring_force(
+            len, l0, spring_vel, unit_stiffness, unit_damping, 0.0, 0.0)
+        @test dead(9.5, 1.0) == 0.0
+        @test dead(10.5, 1.0) ≈ unit_stiffness * 0.5 / 10.5 - unit_damping / 10.5
 
         println("\n  ====== stiffness taut $(round(stiffness_of(10.5); sigdigits=4)), " *
                 "slack $(round(stiffness_of(9.5); sigdigits=4)); damping " *


### PR DESCRIPTION
Two related knobs for slack lines, both live in the right-hand side.

### `Segment(...; compression_damping_frac)`

Scales the damping term of a segment the way `compression_frac` scales the
stiffness:

```julia
taut     = len > l0
damping  = ifelse(taut, unit_damping, compression_damping_frac * unit_damping) / len
stiffness = ifelse(taut, unit_stiffness / len, compression_frac * unit_stiffness / len)
spring   = stiffness * (len - l0) - damping * spring_vel
```

The default `1.0` is the previous behaviour: damping is unaffected by
compression, so the force stays continuous at `len == l0`, but the damping
*ratio* jumps by `1/sqrt(compression_frac)` the moment a segment goes slack —
on a taut bridle that sits right at the crossing, so the effective damping
ratio flickers between two values.

Setting `compression_damping_frac = compression_frac` gives one damping ratio on
both branches instead. `compression_damping_frac = compression_frac = 0` makes a
slack segment carry no force at all, which is what a rope actually does, at the
cost of a force step of `unit_damping / l0 · spring_vel` at the crossing. The
trade-off is documented on `segment_spring_force` so neither choice is silent.

Addresses OpenSourceAWE/SymbolicAWEModels.jl#263.

### `Tether(...; compression_frac, compression_damping_frac)`

A Route 2 tether generated its segments with the `Segment` defaults, so an
auto-expanded line was stuck at `compression_frac = 0.1` and could not use the
above at all. Both are now forwarded to every generated segment, and both are
readable as `tethers` YAML columns.

Together with a winch-less tether holding its length fixed, this makes Route 2
the way to split one line into several segments without writing every segment
and intermediate point out by hand — which is how V3Kite now discretises its
bridle.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

