### PR TITLE
Read a fitted wing's pose back from its weighted reference points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@
   scene-mutating `plot!` stays on `Makie.plot!`.
 
 ### Fixed
+- `KernelBackend` reads a fitted (`KINEMATIC`) wing's pose back from the weighted
+  blend of its reference points, as `MonolithBackend` does. The read-back kept
+  only the first point of each `WeightedRefPoints`, so a wing whose `origin_idx`,
+  `z_ref_points` or `y_ref_points` name several points reported the wrong
+  `pos_w`/`vel_w`/`R_b_to_w` — and the apparent wind and reported scalars derived
+  from them. The dynamics were already correct; only the struct read-back was not.
 - A tether with no winch takes its rest length from `params.tethers[i].len`
   instead of an integrated `tether_len` whose derivative is zero, so writing
   `tether.len` retrims a running simulation and no longer needs a `reinit!` to

--- a/src/aero_modes/common.jl
+++ b/src/aero_modes/common.jl
@@ -729,7 +729,9 @@ end
 Recompute a KINEMATIC/PARTICLE wing's kinematic state directly from the current point
 positions/velocities. A KINEMATIC wing is fitted from its ref points rather than
 integrated, so a backend that does not carry these quantities as state (the network)
-reconstructs them here from the struct. Writes the body frame `R_b_to_w`
+reconstructs them here from the struct. `zp1`, `zp2`, `yp1`, `yp2` and `origin` are
+[`WeightedRefPoints`](@ref), so each reference is the weighted blend of its points,
+matching the monolith's `get_ref_position`. Writes the body frame `R_b_to_w`
 ([`wing_frame_columns`](@ref)), the origin pose `pos_w`/`vel_w`, the frame's own
 `ω_b` ([`body_frame_omega`](@ref)), the reported scalars
 ([`write_wing_scalars!`](@ref)), the wing apparent
@@ -740,18 +742,23 @@ fresh apparent wind on either backend.
 function wing_kinematics_from_points!(wing, points, set, am;
         zp1, zp2, yp1, yp2, origin, aero_points,
         base_point = 0, twist_surfaces = nothing)
-    x, y, z = wing_frame_columns(points[zp1].pos_w, points[zp2].pos_w,
-                                 points[yp1].pos_w, points[yp2].pos_w)
+    pos_z1 = get_ref_position_from_points(points, zp1)
+    pos_z2 = get_ref_position_from_points(points, zp2)
+    pos_y1 = get_ref_position_from_points(points, yp1)
+    pos_y2 = get_ref_position_from_points(points, yp2)
+    vel_z1 = get_ref_position_from_points(points, zp1; field = :vel_w)
+    vel_z2 = get_ref_position_from_points(points, zp2; field = :vel_w)
+    vel_y1 = get_ref_position_from_points(points, yp1; field = :vel_w)
+    vel_y2 = get_ref_position_from_points(points, yp2; field = :vel_w)
+    x, y, z = wing_frame_columns(pos_z1, pos_z2, pos_y1, pos_y2)
     R = hcat(x, y, z)
     wing.R_b_to_w .= R
-    wing.pos_w .= points[origin].pos_w
-    wing.vel_w .= points[origin].vel_w
+    wing.pos_w .= get_ref_position_from_points(points, origin)
+    wing.vel_w .= get_ref_position_from_points(points, origin; field = :vel_w)
     axes = (collect(x), collect(y), collect(z))
     wing.ω_b .= body_frame_omega(axes,
-        wing_frame_rates(points[zp1].pos_w, points[zp2].pos_w,
-            points[yp1].pos_w, points[yp2].pos_w,
-            (points[zp1].vel_w, points[zp2].vel_w,
-             points[yp1].vel_w, points[yp2].vel_w), axes))
+        wing_frame_rates(pos_z1, pos_z2, pos_y1, pos_y2,
+            (vel_z1, vel_z2, vel_y1, vel_y2), axes))
     wind_factor = WindFactor(am, set.profile_law)
     wing.v_wind .= wind_factor(wing.pos_w[3]) .* set.wind_vec
     wing.va_b .= R' * (wing.v_wind .- wing.vel_w .+ wing.wind_disturb)

--- a/src/kernel_backend/state.jl
+++ b/src/kernel_backend/state.jl
@@ -89,15 +89,17 @@ end
 The reference points a fitted (`KINEMATIC`) wing's kinematics are rebuilt from after
 a step. Such a wing has no state of its own — its frame, apparent wind and per-point
 apparent wind are functions of where its points ended up, which is what
-[`wing_kinematics_from_points!`](@ref) computes.
+[`wing_kinematics_from_points!`](@ref) computes. Each reference is the wing's own
+[`WeightedRefPoints`](@ref), so a blend of several points is rebuilt at the same
+weights the [`Wiring`](@ref) feeds the kinematic body kernel.
 """
 struct KinematicWingReadout
     body::Int
-    z1::Int
-    z2::Int
-    y1::Int
-    y2::Int
-    origin::Int
+    z1::WeightedRefPoints
+    z2::WeightedRefPoints
+    y1::WeightedRefPoints
+    y2::WeightedRefPoints
+    origin::WeightedRefPoints
     aero_points::Vector{Int}
 end
 
@@ -188,9 +190,8 @@ end
 """
     kinematic_wing_readouts(sys_struct)
 
-One [`KinematicWingReadout`](@ref) per `KINEMATIC` body, resolving its reference points
-and its aerodynamic surface points once. A weighted reference collapses to its first
-point here, which is what the reconstruction reads.
+One [`KinematicWingReadout`](@ref) per `KINEMATIC` body, holding its weighted
+reference points and its aerodynamic surface points, resolved once.
 """
 function kinematic_wing_readouts(sys_struct)
     readouts = KinematicWingReadout[]
@@ -198,9 +199,9 @@ function kinematic_wing_readouts(sys_struct)
         body.type == KINEMATIC || continue
         aero = [i for (i, point) in enumerate(sys_struct.points)
                 if point.is_wing_node && point.wing_idx == idx]
-        push!(readouts, KinematicWingReadout(idx, body.z_ref_points[1].ids[1],
-            body.z_ref_points[2].ids[1], body.y_ref_points[1].ids[1],
-            body.y_ref_points[2].ids[1], body.origin.ids[1], aero))
+        push!(readouts, KinematicWingReadout(idx, body.z_ref_points[1],
+            body.z_ref_points[2], body.y_ref_points[1],
+            body.y_ref_points[2], body.origin, aero))
     end
     return readouts
 end

--- a/test/test_yaml_weighted_ref.jl
+++ b/test/test_yaml_weighted_ref.jl
@@ -14,6 +14,7 @@ if abspath(PROGRAM_FILE) == abspath(@__FILE__)
 end
 
 using Test
+using LinearAlgebra
 using SymbolicAWEModels
 using SymbolicAWEModels: KVec3, WeightedRefPoints,
     VortexStepMethod
@@ -155,5 +156,19 @@ transforms:
     sam = SymbolicAWEModel(set, sys)
     integ = init!(sam; prn=false)
     @test integ !== nothing
+
+    # The fitted pose read back after a step must use the
+    # weights, not just the first point of each reference.
+    next_step!(sam)
+    points = sam.sys_struct.points
+    wing = sam.sys_struct.bodies[1]
+    blend(ref) = sum(w * points[i].pos_w
+                     for (i, w) in zip(ref.ids, ref.weights))
+    @test wing.pos_w ≈ blend(wing.origin)
+    @test wing.vel_w ≈ sum(w * points[i].vel_w
+        for (i, w) in zip(wing.origin.ids, wing.origin.weights))
+    z_axis = normalize(blend(wing.z_ref_points[2]) -
+                       blend(wing.z_ref_points[1]))
+    @test wing.R_b_to_w[:, 3] ≈ z_axis
 end
 nothing


### PR DESCRIPTION
Follow-up to #270.

`KinematicWingReadout` collapsed each `WeightedRefPoints` to its first point, so a
`KINEMATIC` wing whose `origin_idx`, `z_ref_points` or `y_ref_points` name several
points reported the wrong `pos_w`, `vel_w` and `R_b_to_w` on the `KernelBackend` —
and the apparent wind and reported scalars derived from them. The dynamics already
used the weights; only the struct read-back did not.

The readout now carries the `WeightedRefPoints` themselves, and
`wing_kinematics_from_points!` blends through `get_ref_position_from_points`, the
same helper the monolith uses.

`test_yaml_weighted_ref.jl` gains a read-back check after a step: 16/16 on both
backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)