### PR TITLE
Blend a panel's chord direction by panel spacing, as VSM does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@
   scene-mutating `plot!` stays on `Makie.plot!`.
 
 ### Fixed
+- The live aero modes (`ContinuousAero`, `AeroPressure`) take a panel's chord
+  direction between the two bounding sections blended by panel spacing, as
+  `VortexStepMethod` does, instead of at their midpoint. On a non-uniformly
+  panelled wing that midpoint tilted the whole airfoil frame: the angle of attack
+  was off by 1.9e-4 rad and the per-panel force by 0.1%, a systematic bias that
+  partly cancels spanwise and so never showed up in the wing total. Every
+  per-panel quantity now matches VSM to machine precision. The weights are
+  refreshed with the frozen circulation, so they follow the deforming mesh. They
+  are a new parameter, so a model cached before this needs `remake=true` once.
 - A tether with no winch takes its rest length from `params.tethers[i].len`
   instead of an integrated `tether_len` whose derivative is zero, so writing
   `tether.len` retrims a running simulation and no longer needs a `reinit!` to

--- a/docs/src/private_functions.md
+++ b/docs/src/private_functions.md
@@ -355,6 +355,8 @@ SymbolicAWEModels.set_refined_panel_va!
 SymbolicAWEModels.surface_node_forces
 SymbolicAWEModels.build_mesh_maps!
 SymbolicAWEModels.store_induced_velocity!
+SymbolicAWEModels.store_chord_weights!
+SymbolicAWEModels.size_frozen_panel_buffers!
 SymbolicAWEModels.build_section_interp
 SymbolicAWEModels.section_interp_caches
 SymbolicAWEModels.aero_section_columns

--- a/src/aero_modes/common.jl
+++ b/src/aero_modes/common.jl
@@ -251,8 +251,9 @@ function panel_span_signs(wing, spanwise)
 end
 
 """
-    build_panel_force_eqs(sec_le, sec_te, sec_va, sec_rho, vind_p, cl, cd, cm,
-                          spanwise, scale, orient) -> (eqs, vars, panel_force, panel_couple)
+    build_panel_force_eqs(sec_le, sec_te, sec_va, sec_rho, vind_p, chord_w,
+                          cl, cd, cm, spanwise, scale,
+                          orient) -> (eqs, vars, panel_force, panel_couple)
 
 Shared per-refined-panel VSM force assembly for the live particle aero modes
 ([`ContinuousAero`](@ref), [`AeroPressure`](@ref)). Re-expresses
@@ -270,7 +271,8 @@ the caller's scatter (strut couple or surface pattern).
 the matching air densities; they may be live (interpolated from structure) or
 constant (a fixed mesh). `spanwise` is the wing spanwise direction, `scale` the
 chord-scale factor. `orient` is the per-panel `±1` span/normal sign from
-[`panel_span_signs`](@ref).
+[`panel_span_signs`](@ref) and `chord_w` the per-panel chord blend weight from
+[`store_chord_weights!`](@ref).
 
 `delta` is an optional length-`n_panels` vector of symbolic per-panel flap
 deflections δ. When given the polars are evaluated as `cl(i, alpha[i], delta[i])`
@@ -278,8 +280,8 @@ deflections δ. When given the polars are evaluated as `cl(i, alpha[i], delta[i]
 mode without a flap ([`ContinuousAero`](@ref)) is untouched.
 """
 function build_panel_force_eqs(sec_le, sec_te, sec_va, sec_rho,
-                               vind_p, cl, cd, cm, spanwise, scale, orient;
-                               delta=nothing)
+                               vind_p, chord_w, cl, cd, cm, spanwise, scale,
+                               orient; delta=nothing)
     n_panels = length(sec_le) - 1
     slots = panel_force_slots(n_panels)
     eqs = Equation[]
@@ -289,7 +291,7 @@ function build_panel_force_eqs(sec_le, sec_te, sec_va, sec_rho,
             (sec_va[i], sec_va[i + 1], sec_rho[i], sec_rho[i + 1],
              [vind_p[c, i] for c in 1:3]),
             (PanelPolar(cl, i), PanelPolar(cd, i), PanelPolar(cm, i)),
-            spanwise, scale, orient[i],
+            spanwise, scale, orient[i], chord_w[i],
             delta === nothing ? nothing : delta[i]))
     end
 
@@ -326,27 +328,30 @@ end
 panel_force_vars(slots) = Any[values(slots)...]
 
 """
-    panel_force_eqs(slots, i, sections, flow, polars, spanwise, scale, orient, delta)
+    panel_force_eqs(slots, i, sections, flow, polars, spanwise, scale, orient,
+                    chord_weight, delta)
 
 One panel's aerodynamic equations, writing into column `i` of the symbolic arrays
 in `slots`. `sections` is `(le_1, te_1, le_2, te_2)` in body frame, `flow` is
 `(va_1, va_2, rho_1, rho_2, v_ind)` and `polars` the `(cl, cd, cm)` callables,
-indexed by the panel number the polar tables were built for. `delta` is the flap
-deflection or `nothing` for the 2-argument polars.
+indexed by the panel number the polar tables were built for. `chord_weight` is the
+section-1 share of the chord-direction blend ([`store_chord_weights!`](@ref)).
+`delta` is the flap deflection or `nothing` for the 2-argument polars.
 
 Every quantity it reads belongs to this panel alone, so the same equations serve a
 whole-wing system (looped by [`build_panel_force_eqs`](@ref)) and a per-panel
 component compiled once and instantiated for each panel.
 """
 function panel_force_eqs(slots, i, sections, flow, polars, spanwise, scale,
-                         orient, delta)
+                         orient, chord_weight, delta)
     (; x_airf, y_airf, z_airf, v_eff, chord, width, alpha, q_dyn,
        dir_lift, dir_drag, panel_force, panel_couple) = slots
     le_1, te_1, le_2, te_2 = sections
     va_1, va_2, rho_1, rho_2, vind = flow
     cl, cd, cm = polars
 
-    chord_vec = 0.5 * (te_1 + te_2) - 0.5 * (le_1 + le_2)
+    near, far = chord_weight, 1 - chord_weight
+    chord_vec = (near * te_1 + far * te_2) - (near * le_1 + far * le_2)
     x_unit = chord_vec ./ smooth_norm(chord_vec)
     span_vec = (0.75 * le_1 + 0.25 * te_1) - (0.75 * le_2 + 0.25 * te_2)
     y_unit = orient .* (span_vec ./ smooth_norm(span_vec))
@@ -475,6 +480,7 @@ function Base.getproperty(panel::PanelAero, sym::Symbol)
     mode = getfield(panel, :mode)
     i = getfield(panel, :idx)
     sym === :v_ind && return mode.v_ind[:, i]
+    sym === :chord_weight && return mode.chord_weight[i]
     sym === :le_offset_a && return mode.section_le_offset[:, i]
     sym === :te_offset_a && return mode.section_te_offset[:, i]
     sym === :le_offset_b && return mode.section_le_offset[:, i + 1]
@@ -637,6 +643,57 @@ zero_weight_pair() = zeros(SimFloat, 2)
 scatter_entry_list(totals) =
     sort!([(panel, point, total[1], total[2])
            for ((panel, point), total) in totals])
+
+"""
+    store_chord_weights!(chord_weight, body_aero)
+
+Freeze each refined panel's chord blend weight into `chord_weight` (n_panels): the
+share of section 1 in the leading- and trailing-edge blend whose difference gives
+the panel's chord direction. `VortexStepMethod` weights that blend by panel
+spacing rather than taking the midpoint, so a panel next to a narrower neighbour
+leans towards it, and the weight follows the mesh as the wing deforms. Written at
+the same refresh as [`store_induced_velocity!`](@ref).
+"""
+function store_chord_weights!(chord_weight, body_aero)
+    panels = body_aero.panels
+    n_panels = length(panels)
+    length(chord_weight) == n_panels || error(
+        "chord-weight buffer is stale ($(length(chord_weight)) for $n_panels " *
+        "panels); reinitialize the model.")
+    if n_panels < 2
+        fill!(chord_weight, 0.5)
+        return nothing
+    end
+    for i in 1:n_panels
+        own = panels[i].width
+        spacing_share = if i == 1
+            own / (own + panels[2].width)
+        elseif i == n_panels
+            panels[n_panels - 1].width / (panels[n_panels - 1].width + own)
+        else
+            0.25 * (panels[i - 1].width / (panels[i - 1].width + own) +
+                    own / (own + panels[i + 1].width) + 1)
+        end
+        chord_weight[i] = 1 - spacing_share
+    end
+    return nothing
+end
+
+"""
+    size_frozen_panel_buffers!(mode, n_panels)
+
+Size the per-panel buffers every live VSM mode freezes at a refresh — the induced
+velocity and the chord blend weight — reallocating only when the refined mesh
+changed. The chord weights start at the midpoint, which is what they are on a
+uniformly panelled wing.
+"""
+function size_frozen_panel_buffers!(mode, n_panels::Int)
+    size(mode.v_ind) == (3, n_panels) ||
+        (mode.v_ind = zeros(SimFloat, 3, n_panels))
+    length(mode.chord_weight) == n_panels ||
+        (mode.chord_weight = fill(SimFloat(0.5), n_panels))
+    return nothing
+end
 
 """
     store_induced_velocity!(v_ind, body_aero, gamma)
@@ -1447,8 +1504,9 @@ end
 """
     solve_and_freeze_circulation!(mode, wing)
 
-Solve and freeze the per-refined-panel induced velocity into `mode.v_ind`, shared by
-the continuous VSM modes. Warm starting is `VortexStepMethod.solve!`'s own, gated by
+Solve and freeze the per-refined-panel induced velocity into `mode.v_ind` and the
+chord blend weights into `mode.chord_weight`, shared by the continuous VSM modes.
+Warm starting is `VortexStepMethod.solve!`'s own, gated by
 `use_gamma_prev`. Errors on a non-converged or non-finite solve.
 """
 function solve_and_freeze_circulation!(mode, wing)
@@ -1459,6 +1517,7 @@ function solve_and_freeze_circulation!(mode, wing)
             "(non-converged or non-finite) on wing $(wing.idx)"))
     end
     store_induced_velocity!(mode.v_ind, body_aero, solver.lr.gamma_new)
+    store_chord_weights!(mode.chord_weight, body_aero)
     return nothing
 end
 

--- a/src/aero_modes/continuous.jl
+++ b/src/aero_modes/continuous.jl
@@ -19,6 +19,8 @@ mutable struct ContinuousAero{E} <: AbstractVSMAero
     engine::Union{Nothing, E}
     "Frozen body-frame induced velocity per refined panel (3 × n_panels)."
     v_ind::Matrix{SimFloat}
+    "Frozen section-1 share of each refined panel's chord blend (n_panels)."
+    chord_weight::Vector{SimFloat}
     "Left strut (unrefined section) of each refined section (n_panels + 1)."
     section_left_strut::Vector{Int64}
     "Left-strut weight: section = w·strut[left] + (1−w)·strut[left+1]."
@@ -31,18 +33,22 @@ mutable struct ContinuousAero{E} <: AbstractVSMAero
     cl::Any
     cd::Any
     cm::Any
-    ContinuousAero{E}(engine, v_ind, section_left_strut, section_left_weight,
-        section_le_offset, section_te_offset, cl, cd, cm) where {E} =
-        new{E}(engine, v_ind, section_left_strut, section_left_weight,
-            section_le_offset, section_te_offset, cl, cd, cm)
+    ContinuousAero{E}(engine, v_ind, chord_weight, section_left_strut,
+        section_left_weight, section_le_offset, section_te_offset,
+        cl, cd, cm) where {E} =
+        new{E}(engine, v_ind, chord_weight, section_left_strut,
+            section_left_weight, section_le_offset, section_te_offset,
+            cl, cd, cm)
 end
 
 ContinuousAero() =
-    ContinuousAero{VSMEngine}(nothing, zeros(SimFloat, 3, 0), Int64[], SimFloat[],
+    ContinuousAero{VSMEngine}(nothing, zeros(SimFloat, 3, 0), SimFloat[],
+                   Int64[], SimFloat[],
                    zeros(SimFloat, 3, 0), zeros(SimFloat, 3, 0),
                    nothing, nothing, nothing)
 attach_engine!(mode::ContinuousAero, engine::VSMEngine) =
-    ContinuousAero{typeof(engine)}(engine, mode.v_ind, mode.section_left_strut,
+    ContinuousAero{typeof(engine)}(engine, mode.v_ind, mode.chord_weight,
+        mode.section_left_strut,
         mode.section_left_weight, mode.section_le_offset, mode.section_te_offset,
         mode.cl, mode.cd, mode.cm)
 
@@ -117,7 +123,7 @@ ContinuousPolar(body_aero, coef) = ContinuousPolar(AeroHandle(body_aero), coef)
 """
     build_mesh_maps!(mode::ContinuousAero)
 
-Size the frozen induced-velocity buffer, set the polar callables, and freeze the
+Size the frozen per-panel buffers, set the polar callables, and freeze the
 refined-section → strut interpolation caches via [`build_section_interp`](@ref).
 """
 function build_mesh_maps!(mode::ContinuousAero)
@@ -126,8 +132,7 @@ function build_mesh_maps!(mode::ContinuousAero)
     mode.section_left_strut, mode.section_left_weight,
         mode.section_le_offset, mode.section_te_offset =
         build_section_interp(vsm_wing)
-    size(mode.v_ind) == (3, n_panels) ||
-        (mode.v_ind = zeros(SimFloat, 3, n_panels))
+    size_frozen_panel_buffers!(mode, n_panels)
     body_aero = mode.vsm_aero
     mode.cl = ContinuousPolar(body_aero, VortexStepMethod.calculate_cl)
     mode.cd = ContinuousPolar(body_aero, VortexStepMethod.calculate_cd)
@@ -191,6 +196,7 @@ function aero_component(mode::ContinuousAero, wing::ParticleWing, sys_struct;
                         name, params=nothing)
     wing_idx = wing.idx
     vind_p = params.wings[wing_idx].aero.v_ind
+    chord_w = params.wings[wing_idx].aero.chord_weight
     cl = params.wings[wing_idx].aero.cl   # callable flat params: `cl(panel_idx, α)`
     cd = params.wings[wing_idx].aero.cd
     cm = params.wings[wing_idx].aero.cm
@@ -215,7 +221,8 @@ function aero_component(mode::ContinuousAero, wing::ParticleWing, sys_struct;
 
     orient = panel_span_signs(wing, spanwise)
     eqs, panel_vars, panel_force, panel_couple = build_panel_force_eqs(
-        sec_le, sec_te, sec_va, sec_rho, vind_p, cl, cd, cm, spanwise, scale, orient)
+        sec_le, sec_te, sec_va, sec_rho, vind_p, chord_w, cl, cd, cm, spanwise,
+        scale, orient)
     vars = particle_unknowns(connectors)
     append!(vars, panel_vars)
 
@@ -238,7 +245,7 @@ function aero_component(mode::ContinuousAero, wing::ParticleWing, sys_struct;
     for k in 1:num_points
         eqs = [eqs; connectors.point_force[:, k] ~ point_force[k]]
     end
-    return System(eqs, t, vars, [vind_p, cl, cd, cm]; name)
+    return System(eqs, t, vars, [vind_p, chord_w, cl, cd, cm]; name)
 end
 
 # ==================== per-panel decomposition ==================== #

--- a/src/aero_modes/pressure.jl
+++ b/src/aero_modes/pressure.jl
@@ -39,6 +39,8 @@ mutable struct AeroPressure{E} <: AbstractVSMAero
     frame_tol_frac::SimFloat
     "Frozen body-frame induced velocity per refined panel (3 × n_panels)."
     v_ind::Matrix{SimFloat}
+    "Frozen section-1 share of each refined panel's chord blend (n_panels)."
+    chord_weight::Vector{SimFloat}
     "Frozen body-frame traction per contour node, panel-major (3 × Σ nodes)."
     traction::Matrix{SimFloat}
     "Each wing point's constant force: its nodes' `traction` less its share of `traction_net`."
@@ -59,25 +61,28 @@ mutable struct AeroPressure{E} <: AbstractVSMAero
     section_le_offset::Matrix{SimFloat}
     "Frozen body-frame TE billow offset off the strut line (3 × n_sections)."
     section_te_offset::Matrix{SimFloat}
-    AeroPressure{E}(engine, station_point, frame_tol_frac, v_ind, traction,
-        point_offset, traction_net, cl, cd, cm, panel_twist_surface,
+    AeroPressure{E}(engine, station_point, frame_tol_frac, v_ind, chord_weight,
+        traction, point_offset, traction_net, cl, cd, cm, panel_twist_surface,
         section_left_strut, section_left_weight, section_le_offset,
         section_te_offset) where {E} =
-        new{E}(engine, station_point, frame_tol_frac, v_ind, traction,
-               point_offset, traction_net, cl, cd, cm, panel_twist_surface,
+        new{E}(engine, station_point, frame_tol_frac, v_ind, chord_weight,
+               traction, point_offset, traction_net, cl, cd, cm,
+               panel_twist_surface,
                section_left_strut, section_left_weight, section_le_offset,
                section_te_offset)
 end
 
 AeroPressure(; frame_tol_frac=2.0) =
     AeroPressure{VSMEngine}(nothing, Vector{Vector{Int64}}(),
-        SimFloat(frame_tol_frac), zeros(SimFloat, 3, 0), zeros(SimFloat, 3, 0),
+        SimFloat(frame_tol_frac), zeros(SimFloat, 3, 0), SimFloat[],
+        zeros(SimFloat, 3, 0),
         Dict{Int64, Vector{SimFloat}}(), zeros(SimFloat, 3, 0),
         nothing, nothing, nothing, Int64[],
         Int64[], SimFloat[], zeros(SimFloat, 3, 0), zeros(SimFloat, 3, 0))
 attach_engine!(mode::AeroPressure, engine::VSMEngine) =
     AeroPressure{typeof(engine)}(engine, mode.station_point, mode.frame_tol_frac,
-        mode.v_ind, mode.traction, mode.point_offset, mode.traction_net,
+        mode.v_ind, mode.chord_weight,
+        mode.traction, mode.point_offset, mode.traction_net,
         mode.cl, mode.cd, mode.cm,
         mode.panel_twist_surface, mode.section_left_strut,
         mode.section_left_weight, mode.section_le_offset, mode.section_te_offset)
@@ -116,6 +121,7 @@ function aero_component(mode::AeroPressure, wing::ParticleWing, sys_struct;
                         name, params=nothing)
     wing_idx = wing.idx
     vind_p = params.wings[wing_idx].aero.v_ind
+    chord_w = params.wings[wing_idx].aero.chord_weight
     cl = params.wings[wing_idx].aero.cl
     cd = params.wings[wing_idx].aero.cd
     cm = params.wings[wing_idx].aero.cm
@@ -150,8 +156,8 @@ function aero_component(mode::AeroPressure, wing::ParticleWing, sys_struct;
     orient = panel_span_signs(wing, spanwise)
     delta = has_flap_coupling ? collect(connectors.delta) : nothing
     eqs, panel_vars, panel_force, _ = build_panel_force_eqs(
-        sec_le, sec_te, sec_va, sec_rho, vind_p, cl, cd, cm, spanwise, scale, orient;
-        delta)
+        sec_le, sec_te, sec_va, sec_rho, vind_p, chord_w, cl, cd, cm, spanwise,
+        scale, orient; delta)
     vars = particle_unknowns(connectors)
     append!(vars, panel_vars)
 
@@ -173,7 +179,7 @@ function aero_component(mode::AeroPressure, wing::ParticleWing, sys_struct;
         eqs = [eqs; connectors.point_force[:, k] ~ point_force[k]]
     end
     return System(eqs, t, vars,
-        [vind_p, cl, cd, cm, traction_p, traction_net_p]; name)
+        [vind_p, chord_w, cl, cd, cm, traction_p, traction_net_p]; name)
 end
 
 # ==================== build-time panel→flap map + live δ ==================== #
@@ -352,7 +358,8 @@ end
 """
     init_pressure_buffers!(mode::AeroPressure, wing)
 
-Size the frozen state buffers (`v_ind`, `traction`, `traction_net`) to the current
+Size the frozen state buffers (`v_ind`, `chord_weight`, `traction`,
+`traction_net`) to the current
 mesh and set the `cl/cd/cm` polar callables. Run after
 [`build_station_point_map!`](@ref) (needs the per-panel node counts).
 """
@@ -360,8 +367,7 @@ function init_pressure_buffers!(mode::AeroPressure, wing)
     body_aero = wing.vsm_aero
     n_panels = length(body_aero.panels)
     total_nodes = sum(length, mode.station_point)
-    size(mode.v_ind) == (3, n_panels) ||
-        (mode.v_ind = zeros(SimFloat, 3, n_panels))
+    size_frozen_panel_buffers!(mode, n_panels)
     size(mode.traction) == (3, total_nodes) ||
         (mode.traction = zeros(SimFloat, 3, total_nodes))
     size(mode.traction_net) == (3, n_panels) ||

--- a/src/components/components.jl
+++ b/src/components/components.jl
@@ -1842,8 +1842,9 @@ One refined VSM panel's aerodynamic load: its two sections' leading and trailing
 its flap deflection in; its body-frame force and pitching couple out. The physics is
 the shared [`panel_force_eqs`](@ref) on a single column, so the expressions are those a
 whole-wing system emits for this panel. `orient` is the panel's `±1` span sign, baked
-in because it costs a second kernel and saves a parameter on every instance;
-`with_flap` selects the `(α, δ)` polars.
+in because it costs a second kernel and saves a parameter on every instance; the
+chord blend weight cannot be, because it differs per panel and would cost a kernel
+each. `with_flap` selects the `(α, δ)` polars.
 """
 function AeroPanel(s, params, wing_idx, panel_idx, orient; name, with_flap)
     wing = params.reg.sys_struct.wings[wing_idx]
@@ -1872,7 +1873,7 @@ function AeroPanel(s, params, wing_idx, panel_idx, orient; name, with_flap)
     flow = (collect(io[5]), collect(io[6]), io[7], io[8], collect(panel.v_ind))
     eqs = panel_force_eqs(slots, 1, sections, flow,
                           (panel.cl, panel.cd, panel.cm),
-                          spanwise, scale, orient, delta)
+                          spanwise, scale, orient, panel.chord_weight, delta)
     append!(eqs, collect(io[9]) .~ collect(slots.panel_force[:, 1]))
     append!(eqs, collect(io[10]) .~ collect(slots.panel_couple[:, 1]))
     vars = [io; panel_force_vars(slots)]

--- a/test/test_continuous_modes.jl
+++ b/test/test_continuous_modes.jl
@@ -154,12 +154,6 @@ group_means(groups, values) =
             # reading a compiled model, whose variable names are codegen
             # artefacts and which the KernelBackend does not expose at all.
             #
-            # Everything independent of the chord direction is exact. VSM takes
-            # that direction between two section blends weighted by panel spacing
-            # where the equations use the midpoint; `blend` measures the gap, and
-            # bounds every axis-dependent error. It is zero on a uniformly
-            # panelled wing, where the whole reconstruction is then exact.
-            #
             # The frozen `mode.v_ind` is the reference circulation because VSM
             # builds its forces from the one its last iteration was handed;
             # `solver.lr.gamma_new` is already a step past it.
@@ -175,7 +169,7 @@ group_means(groups, values) =
                 force_scale = maximum(norm(Vector(solver.sol.f_body_3D[:, i]))
                                       for i in eachindex(panels))
                 @test force_scale > 0.1
-                names = (:blend, :chord, :width, :span_axis, :q_dyn, :chord_axis,
+                names = (:chord, :width, :span_axis, :q_dyn, :chord_axis,
                          :normal_axis, :alpha, :force, :couple)
                 worst = Dict(name => 0.0 for name in names)
                 record(name, value) = worst[name] = max(worst[name], value)
@@ -191,14 +185,10 @@ group_means(groups, values) =
                          mode.v_ind[:, i]),
                         alpha -> (VortexStepMethod.calculate_cl(panel, alpha),
                             VortexStepMethod.calculate_cd_cm(panel, alpha)...),
-                        spanwise, scale, orient[i])
+                        spanwise, scale, orient[i], mode.chord_weight[i])
                     reference_q = 0.5 * solver.density * solver.lr.v_a_dist[i]^2
                     reference_couple = solver.sol.panel_moment_dist[i] *
                         panel.width / panel.chord .* Vector(panel.z_airf)
-                    record(:blend, norm(
-                        normalize(Vector(panel.control_point) .-
-                                  Vector(panel.aero_center)) .-
-                        normalize(0.5 .* (te_1 .+ te_2) .- 0.5 .* (le_1 .+ le_2))))
                     record(:chord, abs(result.chord - panel.chord) / panel.chord)
                     record(:width, abs(result.width - panel.width) / panel.width)
                     record(:span_axis, norm(result.y_airf .- Vector(panel.y_airf)))
@@ -213,30 +203,23 @@ group_means(groups, values) =
                     record(:couple, norm(result.couple .- reference_couple) /
                                     force_scale)
                 end
-                println("  [$(case.name)] per-panel: blend=",
-                    "$(round(worst[:blend]; sigdigits=3)), ",
+                println("  [$(case.name)] per-panel: ",
                     join(("$name=$(round(worst[name]; sigdigits=3))"
-                          for name in names[2:end]), ", "))
-                # Independent of the chord direction, so exact either way.
-                @test worst[:chord] < 1e-14
-                @test worst[:width] < 1e-14
-                @test worst[:span_axis] < 1e-14
+                          for name in names), ", "))
+                for name in (:chord, :width, :span_axis, :chord_axis,
+                             :normal_axis, :alpha)
+                    @test worst[name] < 1e-14
+                end
                 @test worst[:q_dyn] < 1e-13
-                # Axis-dependent. The force picks up the lift-curve slope on top
-                # of the angle the tilted chord direction costs.
-                @test worst[:chord_axis] < 2 * worst[:blend] + 1e-13
-                @test worst[:normal_axis] < 2 * worst[:blend] + 1e-13
-                @test worst[:alpha] < 2 * worst[:blend] + 1e-13
-                @test worst[:force] < 10 * worst[:blend] + 1e-13
-                @test worst[:couple] < 10 * worst[:blend] + 1e-13
+                @test worst[:force] < 1e-13
+                @test worst[:couple] < 1e-13
             end
 
             @testset "solve-point parity with full VSM" begin
                 # Reference: full nonlinear solve + calc_forces! on the same panel
                 # apparent wind the refresh used. Remaining differences: the
-                # per-panel va assignment (nearest strut vs interpolated), the
-                # corrected-AoA direction triad, and VSM's spanwise aero-center
-                # weighting.
+                # per-panel va assignment (nearest strut vs interpolated) and the
+                # corrected-AoA direction triad.
                 VortexStepMethod.solve!(wing.vsm_solver, wing.vsm_aero)
                 force_reference = vec(sum(wing.vsm_solver.sol.f_body_3D, dims=2))
                 @test all(isfinite, force_symbolic)

--- a/test/util.jl
+++ b/test/util.jl
@@ -235,7 +235,7 @@ end
 
 """
     evaluate_panel_equations(sections, flow, coefficients, spanwise, scale,
-                             orient) -> NamedTuple
+                             orient, chord_weight) -> NamedTuple
 
 One panel of `panel_force_eqs` evaluated numerically. The equations are built on
 numeric `sections`/`flow` and substituted forward in the order they are emitted,
@@ -244,13 +244,13 @@ reimplementation of it. `coefficients` maps the resulting angle of attack to
 `(cl, cd, cm)`, which are folded into `force` and `couple`.
 """
 function evaluate_panel_equations(sections, flow, coefficients, spanwise, scale,
-                                  orient)
+                                  orient, chord_weight)
     slots = panel_force_slots(1)
     polar_symbols = [Symbolics.variable(name) for name in (:cl, :cd, :cm)]
     polars = Tuple(_ -> symbol for symbol in polar_symbols)
     values = Dict{Any, Any}()
     for equation in panel_force_eqs(slots, 1, sections, flow, polars, spanwise,
-                                    scale, orient, nothing),
+                                    scale, orient, chord_weight, nothing),
         (left, right) in scalar_equation_pairs(equation)
         values[Symbolics.value(left)] =
             Symbolics.substitute(right, values; fold = Val(true))


### PR DESCRIPTION
Stacked on #274.

`panel_force_eqs` took a panel's chord direction between the *midpoint* of its two
bounding sections. `VortexStepMethod` takes it between two blends weighted by panel
spacing (its `ncp`), so on a non-uniformly panelled wing the whole airfoil frame was
tilted — angle of attack off by 1.9e-4 rad, per-panel force by 0.10%. The bias partly
cancels spanwise, which is why the wing total never showed it and only the per-panel
test in #274 could find it.

### The weight is a parameter, not baked

`assembly.jl` keys aero kernels as `aero_panel_<wing>_up/_down` from `orient` alone, so
panels dedupe to two kernels per wing. Baking a per-panel chord weight would give one
kernel per panel — a cost the codebase has already paid for once. So it travels as a
per-panel parameter through `PanelAero` alongside `v_ind`. Confirmed on a 10-panel wing:
`aero_panel_1_up  ×10`, still one kernel.

It is refreshed in `solve_and_freeze_circulation!` — the one place both live modes
already freeze the circulation — so it follows the deforming mesh rather than being
frozen at build time.

### Result

The per-panel test drops its `blend` allowance and asserts machine precision
unconditionally, which makes the fix self-proving:

| worst over all panels | ContinuousAero before | after |
|---|---|---|
| chord axis | 1.98e-4 | 8.36e-16 |
| normal axis | 1.99e-4 | 7.68e-16 |
| angle of attack | 1.9e-4 rad | 7.49e-16 |
| force | 1.0e-3 | 4.16e-15 |
| couple | 4.25e-5 | 1.66e-16 |

`AeroPressure` was already at machine precision and stays there — its mesh is uniform,
so the two blends coincide.

### Tests

`test_continuous_modes.jl` 86/86 on both backends; `test_aero_modes.jl` 779/779,
`test_continuous_aero.jl` 52/52, `test_pressure_aero.jl` 60/60 + 20/20,
`test_flap_aero.jl` 18/18, `test_flap_beam.jl` 28/28.

The weight is a new parameter, so a model cached before this needs `remake=true` once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)