### PR TITLE
Default reinit! to the built solver, and store the per-point aerodynamic load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CHANGELOG
 
+## v0.15.2 22-08-2026
+
+### Added
+- `reinit!(sam, integrator; solver=integrator.alg, kwargs...)`, which names the
+  integrator it resets and defaults the solver to the one that integrator was
+  built with. The three-argument method takes `solver` as a required argument, and
+  a caller passing a bare `FBDF()` made the monolith backend compile its whole
+  right-hand side a second time at `ForwardDiff.Dual`.
+
+### Fixed
+- `sim_reposition!` reinitializes with the solver `init!` built rather than
+  rebuilding one and dropping its `linsolve`, which on the `KernelBackend` swapped
+  the `KLUFactorization` for a dense one and rebuilt the integrator each
+  reposition.
+
 ## v0.15.1 22-08-2026
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,37 +3,28 @@
 ## v0.15.2 22-08-2026
 
 ### Added
-- `reinit!(sam, integrator; solver=integrator.alg, kwargs...)`, which names the
-  integrator it resets and defaults the solver to the one that integrator was
-  built with. The three-argument method takes `solver` as a required argument, and
-  a caller passing a bare `FBDF()` made the monolith backend compile its whole
-  right-hand side a second time at `ForwardDiff.Dual`.
+- `reinit!(sam, integrator; solver=integrator.alg, kwargs...)`, which defaults the
+  solver to the one the integrator was built with. The three-argument method takes
+  it as a required argument, and a caller passing a bare `FBDF()` made the monolith
+  backend compile its whole right-hand side again at `ForwardDiff.Dual`.
 
 ### Fixed
-- `sim_reposition!` reinitializes with the solver `init!` built rather than
-  rebuilding one and dropping its `linsolve`, which on the `KernelBackend` swapped
-  the `KLUFactorization` for a dense one and rebuilt the integrator each
-  reposition.
-- Every wing node's `aero_force_b`, and with it the `aero_force_x/y/z` log
-  channels, stayed zero under the modes that scatter panel loads (`AeroPressure`,
-  `ContinuousAero`), so `plot` drew no aero arrows at all on such a wing. The load
-  is a quantity the model already computes — the monolith's `aero_force_point_b`,
-  the kernel's `AeroPointForce` — and is now read back into the struct each step
-  by both backends, so it is the live per-node force rather than a refit of it.
-- `update_from_sysstate!` set the wing's aero and tether loads to `NaN` to keep
-  them from being plotted, but `plot` skips a load with `iszero`, so the `NaN` was
-  drawn — and one `NaN` made the shared adaptive arrow scale `NaN`, blanking every
-  aero arrow in a replay. All four loads are restored from the log instead, and the
-  per-point forces with them, so a replay shows the loads of the frame it is on.
-- `plot` drops non-finite loads before scaling the rest, so a load a mode leaves
-  unset can no longer blank the whole layer.
+- `sim_reposition!` reinitializes with the solver `init!` built, rather than
+  rebuilding one and dropping its `linsolve`.
+- Every wing node's `aero_force_b`, and the `aero_force_x/y/z` log channels with it,
+  stayed zero under the modes that scatter panel loads (`AeroPressure`,
+  `ContinuousAero`), so `plot` drew no aero arrows on such a wing. Both backends now
+  read the load back out of the model, where it already existed.
+- `update_from_sysstate!` set the wing's aero and tether loads to `NaN` to keep them
+  unplotted, but `plot` skips a load only with `iszero`, so one `NaN` blanked every
+  aero arrow in a replay through the shared adaptive scale. All four loads and the
+  per-point forces are restored from the log instead.
+- `plot` drops non-finite loads before scaling the rest.
 
 ### Changed
-- `point.aero_force_b` is the one place a per-point aerodynamic load is read from.
-  A mode that scatters panel loads has it read back out of the model; `AeroDirect`
-  keeps writing it at refresh, that field being the parameter its equations read.
-  The private `aero_point_forces` and `stores_point_force` are removed, and
-  `write_aero_forces!` and the Makie extension read the field.
+- `point.aero_force_b` is the one place a per-point aerodynamic load is read from,
+  filled by refresh (`AeroDirect`) or read back out of the model. The private
+  `aero_point_forces` and `stores_point_force` are removed.
 
 ## v0.15.1 22-08-2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@
   the `KLUFactorization` for a dense one and rebuilt the integrator each
   reposition.
 - Every wing node's `aero_force_b`, and with it the `aero_force_x/y/z` log
-  channels, stayed zero under `AeroPressure`: the mode reaches the points
-  symbolically and wrote no per-point force, so `plot` drew no aero arrows at all
-  on a particle wing. The refresh now stores the frozen pattern's per-point load,
-  which sums to the panel forces exactly.
+  channels, stayed zero under the modes that scatter panel loads (`AeroPressure`,
+  `ContinuousAero`), so `plot` drew no aero arrows at all on such a wing. The load
+  is a quantity the model already computes — the monolith's `aero_force_point_b`,
+  the kernel's `AeroPointForce` — and is now read back into the struct each step
+  by both backends, so it is the live per-node force rather than a refit of it.
 - `update_from_sysstate!` set the wing's aero and tether loads to `NaN` to keep
   them from being plotted, but `plot` skips a load with `iszero`, so the `NaN` was
   drawn — and one `NaN` made the shared adaptive arrow scale `NaN`, blanking every
@@ -28,11 +29,11 @@
   unset can no longer blank the whole layer.
 
 ### Changed
-- `point.aero_force_b` is the one place a per-point aerodynamic load is read from,
-  filled at refresh by the modes that compute one (`AeroDirect`, `AeroPressure`;
-  `ContinuousAero` still stores none). The private `aero_point_forces` and
-  `stores_point_force` are removed, and `write_aero_forces!` and the Makie
-  extension read the field.
+- `point.aero_force_b` is the one place a per-point aerodynamic load is read from.
+  A mode that scatters panel loads has it read back out of the model; `AeroDirect`
+  keeps writing it at refresh, that field being the parameter its equations read.
+  The private `aero_point_forces` and `stores_point_force` are removed, and
+  `write_aero_forces!` and the Makie extension read the field.
 
 ## v0.15.1 22-08-2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@
   rebuilding one and dropping its `linsolve`, which on the `KernelBackend` swapped
   the `KLUFactorization` for a dense one and rebuilt the integrator each
   reposition.
+- Every wing node's `aero_force_b`, and with it the `aero_force_x/y/z` log
+  channels, stayed zero under `AeroPressure`: the mode reaches the points
+  symbolically and wrote no per-point force, so `plot` drew no aero arrows at all
+  on a particle wing. The refresh now stores the frozen pattern's per-point load,
+  which sums to the panel forces exactly.
+- `update_from_sysstate!` set the wing's aero and tether loads to `NaN` to keep
+  them from being plotted, but `plot` skips a load with `iszero`, so the `NaN` was
+  drawn — and one `NaN` made the shared adaptive arrow scale `NaN`, blanking every
+  aero arrow in a replay. All four loads are restored from the log instead, and the
+  per-point forces with them, so a replay shows the loads of the frame it is on.
+- `plot` drops non-finite loads before scaling the rest, so a load a mode leaves
+  unset can no longer blank the whole layer.
+
+### Changed
+- `point.aero_force_b` is the one place a per-point aerodynamic load is read from,
+  filled at refresh by the modes that compute one (`AeroDirect`, `AeroPressure`;
+  `ContinuousAero` still stores none). The private `aero_point_forces` and
+  `stores_point_force` are removed, and `write_aero_forces!` and the Makie
+  extension read the field.
 
 ## v0.15.1 22-08-2026
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymbolicAWEModels"
 uuid = "9c9a347c-5289-41db-a9b9-25ccc76c3360"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["Bart van de Lint <bart@vandelint.net> and contributors"]
 
 [workspace]

--- a/docs/src/private_functions.md
+++ b/docs/src/private_functions.md
@@ -386,10 +386,9 @@ SymbolicAWEModels.freeze_traction_pattern!
 SymbolicAWEModels.contour_winding
 SymbolicAWEModels.write_aero_forces!
 SymbolicAWEModels.accumulate_point_offset!
-SymbolicAWEModels.write_point_forces!
 SymbolicAWEModels.restore_point_aero_forces!
-SymbolicAWEModels.wing_nodes_of
-SymbolicAWEModels.zero_point_forces!
+SymbolicAWEModels.carries_point_aero
+SymbolicAWEModels.point_aero_force_array
 SymbolicAWEModels.zero_aero_force
 SymbolicAWEModels.PanelAeroList
 SymbolicAWEModels.PanelAero

--- a/docs/src/private_functions.md
+++ b/docs/src/private_functions.md
@@ -312,7 +312,6 @@ SymbolicAWEModels.require_vsm_engine
 SymbolicAWEModels.couples_to_sections
 SymbolicAWEModels.has_vsm_wing
 SymbolicAWEModels.provides_aero_override
-SymbolicAWEModels.stores_point_force
 SymbolicAWEModels.aero_mode_tag
 SymbolicAWEModels.calc_side_slip
 SymbolicAWEModels.validate_aero_component
@@ -385,9 +384,12 @@ SymbolicAWEModels.apply_flap_delta!
 SymbolicAWEModels.init_pressure_buffers!
 SymbolicAWEModels.freeze_traction_pattern!
 SymbolicAWEModels.contour_winding
-SymbolicAWEModels.aero_point_forces
 SymbolicAWEModels.write_aero_forces!
 SymbolicAWEModels.accumulate_point_offset!
+SymbolicAWEModels.write_point_forces!
+SymbolicAWEModels.restore_point_aero_forces!
+SymbolicAWEModels.wing_nodes_of
+SymbolicAWEModels.zero_point_forces!
 SymbolicAWEModels.zero_aero_force
 SymbolicAWEModels.PanelAeroList
 SymbolicAWEModels.PanelAero

--- a/docs/src/private_kernel_backend.md
+++ b/docs/src/private_kernel_backend.md
@@ -233,6 +233,7 @@ SymbolicAWEModels.add_aero_inflows!
 SymbolicAWEModels.add_aero_panels!
 SymbolicAWEModels.wire_panel_flaps!
 SymbolicAWEModels.add_aero_point_forces!
+SymbolicAWEModels.aero_force_slots
 SymbolicAWEModels.add_wing_aero_sum!
 SymbolicAWEModels.add_rigid_wing_aero!
 SymbolicAWEModels.add_twist_surfaces!

--- a/docs/src/vsm_coupling.md
+++ b/docs/src/vsm_coupling.md
@@ -296,9 +296,8 @@ on the mode:
   [`update_wing_aero_plot!`](@ref) — methods live in the Makie extension,
   so a custom mode draws with full Makie access (default: draws nothing).
 - **Traits**: [`couples_to_sections`](@ref) (needs per-section twist
-  surfaces; default `false`), [`provides_aero_override`](@ref),
-  [`stores_point_force`](@ref), and the cache controls
-  [`is_builtin_aero`](@ref) / [`aero_hash_id`](@ref) (see below).
+  surfaces; default `false`), [`provides_aero_override`](@ref), and the cache
+  controls [`is_builtin_aero`](@ref) / [`aero_hash_id`](@ref) (see below).
 
 Subtyping [`AbstractVSMAero`](@ref) (a [`VSMEngine`](@ref) in an `engine`
 field, exposed via [`vsm_engine`](@ref)) inherits the VSM implementation of

--- a/ext/SymbolicAWEModelsMakieExt.jl
+++ b/ext/SymbolicAWEModelsMakieExt.jl
@@ -81,9 +81,9 @@ const PLOT_MULTI_GEOMETRY_OBS = Ref{Union{Nothing, Vector{Observable}}}(nothing)
 """
     finite_force_arrows(origins, forces, scale) -> (origins, directions)
 
-Arrows for the loads that have one, scaled so the largest is `scale` long. Forces
-that are not finite are dropped before the rest are sized, so a single unset load
-cannot blank the whole layer through the shared adaptive scale.
+Arrows for `forces`, scaled so the largest is `scale` long. Non-finite forces are
+dropped before the rest are sized, so one unset load cannot blank the layer through
+the shared scale.
 """
 function finite_force_arrows(origins, forces, scale)
     keep = [i for i in eachindex(forces) if all(isfinite, forces[i])]

--- a/ext/SymbolicAWEModelsMakieExt.jl
+++ b/ext/SymbolicAWEModelsMakieExt.jl
@@ -79,6 +79,21 @@ const PLOT_MULTI_SYSTEMS = Ref{Union{Nothing, Vector{<:SystemStructure}}}(nothin
 const PLOT_MULTI_GEOMETRY_OBS = Ref{Union{Nothing, Vector{Observable}}}(nothing)
 
 """
+    finite_force_arrows(origins, forces, scale) -> (origins, directions)
+
+Arrows for the loads that have one, scaled so the largest is `scale` long. Forces
+that are not finite are dropped before the rest are sized, so a single unset load
+cannot blank the whole layer through the shared adaptive scale.
+"""
+function finite_force_arrows(origins, forces, scale)
+    keep = [i for i in eachindex(forces) if all(isfinite, forces[i])]
+    isempty(keep) && return (Point3f[], Vec3f[])
+    max_force = maximum(norm(forces[i]) for i in keep)
+    max_force > 0 || return (Point3f[], Vec3f[])
+    return (origins[keep], [forces[i] * (scale / max_force) for i in keep])
+end
+
+"""
     calculate_segment_force_colors(segments, segment_color)
 
 Calculate segment colors based on their force values.
@@ -878,13 +893,9 @@ function Makie.plot!(ax, sys::SystemStructure;
                 end
             end
 
+            aero_origins, aero_directions =
+                finite_force_arrows(aero_origins, aero_forces_raw, vector_scale)
             if !isempty(aero_origins)
-                # Calculate adaptive force scale
-                max_force = maximum(norm.(aero_forces_raw))
-                # Scale forces to be similar size as vector_scale
-                force_scale = vector_scale / max_force
-                aero_directions = [f * force_scale for f in aero_forces_raw]
-
                 plots[:aero_forces] = arrows3d!(ax, aero_origins, aero_directions,
                                                color=:magenta,
                                                label="Aero Forces")
@@ -923,14 +934,7 @@ function Makie.plot!(ax, sys::SystemStructure;
                     end
                 end
 
-                # Calculate adaptive force scale
-                directions = Vec3f[]
-                if !isempty(forces_raw)
-                    max_force = maximum(norm.(forces_raw))
-                    force_scale = scale / max_force
-                    directions = [f * force_scale for f in forces_raw]
-                end
-                (origins, directions)
+                finite_force_arrows(origins, forces_raw, scale)
             end
 
             plots[:aero_forces] = arrows3d!(ax, @lift($aero_origins_dirs[1]), @lift($aero_origins_dirs[2]),

--- a/src/aero_modes/common.jl
+++ b/src/aero_modes/common.jl
@@ -54,14 +54,6 @@ compiled RHS (the stored-force path of [`AeroDirect`](@ref)).
 """
 provides_aero_override(::AbstractAeroModel) = false
 
-"""
-    stores_point_force(mode::AbstractAeroModel) -> Bool
-
-`true` if a wing node's `aero_force_b` is meaningful for this mode.
-[`AeroNone`](@ref) returns `false` (it produces no force).
-"""
-stores_point_force(::AbstractAeroModel) = true
-
 # ==================== interface: required cache tag ==================== #
 
 """
@@ -209,10 +201,10 @@ end
     frozen_point_force_component(wing::AbstractWing, sys_struct; name, params) -> System
 
 Particle aero component binding each wing node's connector force to its frozen
-`point.aero_force_b` flat parameter (synced every refresh). Shared by the modes
-that store a precomputed per-point force ([`AeroDirect`](@ref),
-[`AeroPressure`](@ref)); the difference between those modes is only how the
-refresh fills `aero_force_b`, not the (identical) symbolic binding.
+`point.aero_force_b` flat parameter (synced every refresh). Used by
+[`AeroDirect`](@ref), the mode whose refresh precomputes a per-point force the
+equations can read back unchanged. Touching the parameter here is what registers
+it, so a mode that does not use this component never gets one.
 """
 function frozen_point_force_component(wing, sys_struct; name, params=nothing)
     points = wing_points(sys_struct, wing)
@@ -228,9 +220,29 @@ function frozen_point_force_component(wing, sys_struct; name, params=nothing)
     return System(eqs, t, particle_unknowns(connectors), flat_ps; name)
 end
 
-function wing_points(sys_struct, wing)
-    return [point for point in sys_struct.points
-            if point.is_wing_node && point.wing_idx == wing.idx]
+wing_points(sys_struct, wing) = wing_nodes_of(wing, sys_struct.points)
+
+"""
+    wing_nodes_of(wing, points) -> Vector{Point}
+
+`wing`'s own nodes out of `points`, in order. The refresh hooks are handed every
+point of the system, so they select with this rather than with `sys_struct`.
+"""
+wing_nodes_of(wing, points) =
+    [point for point in points
+     if point.is_wing_node && point.wing_idx == wing.idx]
+
+"""
+    zero_point_forces!(wing, points)
+
+Clear the body-frame aero force of every one of `wing`'s nodes, so no stale load
+survives a refresh that produces none.
+"""
+function zero_point_forces!(wing, points)
+    for point in wing_nodes_of(wing, points)
+        fill!(point.aero_force_b, 0.0)
+    end
+    return nothing
 end
 
 """
@@ -548,17 +560,6 @@ panel_force + couple weight · panel_couple`. The weights are constants of the m
 the wiring layer carries the whole scatter and no component holds it.
 """
 function aero_scatter_entries end
-
-"""
-    aero_point_forces(mode, wing, sys_struct) -> iterable of (point_idx, force_b)
-
-The body-frame aerodynamic force on each of `wing`'s points, for logging and
-plotting. The fallback reads each point's own `aero_force_b`, which a mode that
-scatters panel loads overrides because it never writes that field.
-"""
-aero_point_forces(::AbstractAeroModel, wing, sys_struct) =
-    ((point.idx, collect(point.aero_force_b))
-     for point in wing_points(sys_struct, wing))
 
 """
     aero_point_offset(mode, params, wing_idx, point_idx)

--- a/src/aero_modes/common.jl
+++ b/src/aero_modes/common.jl
@@ -202,9 +202,8 @@ end
 
 Particle aero component binding each wing node's connector force to its frozen
 `point.aero_force_b` flat parameter (synced every refresh). Used by
-[`AeroDirect`](@ref), the mode whose refresh precomputes a per-point force the
-equations can read back unchanged. Touching the parameter here is what registers
-it, so a mode that does not use this component never gets one.
+[`AeroDirect`](@ref), whose refresh precomputes that force. Touching the parameter
+here is what registers it.
 """
 function frozen_point_force_component(wing, sys_struct; name, params=nothing)
     points = wing_points(sys_struct, wing)

--- a/src/aero_modes/common.jl
+++ b/src/aero_modes/common.jl
@@ -220,29 +220,9 @@ function frozen_point_force_component(wing, sys_struct; name, params=nothing)
     return System(eqs, t, particle_unknowns(connectors), flat_ps; name)
 end
 
-wing_points(sys_struct, wing) = wing_nodes_of(wing, sys_struct.points)
-
-"""
-    wing_nodes_of(wing, points) -> Vector{Point}
-
-`wing`'s own nodes out of `points`, in order. The refresh hooks are handed every
-point of the system, so they select with this rather than with `sys_struct`.
-"""
-wing_nodes_of(wing, points) =
-    [point for point in points
-     if point.is_wing_node && point.wing_idx == wing.idx]
-
-"""
-    zero_point_forces!(wing, points)
-
-Clear the body-frame aero force of every one of `wing`'s nodes, so no stale load
-survives a refresh that produces none.
-"""
-function zero_point_forces!(wing, points)
-    for point in wing_nodes_of(wing, points)
-        fill!(point.aero_force_b, 0.0)
-    end
-    return nothing
+function wing_points(sys_struct, wing)
+    return [point for point in sys_struct.points
+            if point.is_wing_node && point.wing_idx == wing.idx]
 end
 
 """

--- a/src/aero_modes/direct.jl
+++ b/src/aero_modes/direct.jl
@@ -97,7 +97,11 @@ structural points ([`distribute_panel_forces_to_points!`](@ref)). Below
 function refresh_particle_aero!(::AeroDirect, wing, points, va_point_b_vals;
                                 vsm_min_wind=0.5, cold_start=false)
     if norm(wing.va_b) < vsm_min_wind
-        zero_point_forces!(wing, points)
+        for point in points
+            if point.is_wing_node && point.wing_idx == wing.idx
+                fill!(point.aero_force_b, 0.0)
+            end
+        end
         return nothing
     end
 

--- a/src/aero_modes/direct.jl
+++ b/src/aero_modes/direct.jl
@@ -97,11 +97,7 @@ structural points ([`distribute_panel_forces_to_points!`](@ref)). Below
 function refresh_particle_aero!(::AeroDirect, wing, points, va_point_b_vals;
                                 vsm_min_wind=0.5, cold_start=false)
     if norm(wing.va_b) < vsm_min_wind
-        for point in points
-            if point.is_wing_node && point.wing_idx == wing.idx
-                fill!(point.aero_force_b, 0.0)
-            end
-        end
+        zero_point_forces!(wing, points)
         return nothing
     end
 

--- a/src/aero_modes/none.jl
+++ b/src/aero_modes/none.jl
@@ -17,7 +17,6 @@ is_wing(::Body) = true
 
 is_builtin_aero(::AeroNone) = true
 aero_mode_tag(::AeroNone) = "none"
-stores_point_force(::AeroNone) = false
 
 """
     aero_component(::AeroNone, wing::ParticleWing, sys_struct; name)

--- a/src/aero_modes/pressure.jl
+++ b/src/aero_modes/pressure.jl
@@ -444,10 +444,9 @@ end
 Solve at the per-panel apparent wind the symbolic RHS uses
 ([`set_refined_panel_va!`](@ref)), freezing the induced velocity and the per-node
 surface traction pattern ([`freeze_traction_pattern!`](@ref)). Point forces are
-re-derived symbolically each RHS step and read back from the model into each node's
-`aero_force_b`, so nothing here recomputes them. Below `vsm_min_wind` all frozen
-buffers are zeroed, the per-point offsets included, so no stale constant force
-survives — the point forces then follow, being a scatter of what was zeroed.
+re-derived symbolically each RHS step and read back into each node's
+`aero_force_b`. Below `vsm_min_wind` all frozen buffers are zeroed, the per-point
+offsets included, so no stale constant force survives.
 """
 function refresh_particle_aero!(mode::AeroPressure, wing, points,
                                 va_point_b_vals; vsm_min_wind=0.5,
@@ -467,7 +466,6 @@ function refresh_particle_aero!(mode::AeroPressure, wing, points,
         "AeroPressure: non-finite traction pattern on wing $(wing.idx)"))
     return nothing
 end
-
 
 """
     contour_winding(section) -> Float64

--- a/src/aero_modes/pressure.jl
+++ b/src/aero_modes/pressure.jl
@@ -444,10 +444,10 @@ end
 Solve at the per-panel apparent wind the symbolic RHS uses
 ([`set_refined_panel_va!`](@ref)), freezing the induced velocity and the per-node
 surface traction pattern ([`freeze_traction_pattern!`](@ref)). Point forces are
-re-derived symbolically each RHS step; [`write_point_forces!`](@ref) additionally
-stores the frozen pattern's per-point load for logging and plotting. Below
-`vsm_min_wind` all frozen buffers are zeroed, the per-point offsets and the stored
-point forces included, so no stale constant force survives.
+re-derived symbolically each RHS step and read back from the model into each node's
+`aero_force_b`, so nothing here recomputes them. Below `vsm_min_wind` all frozen
+buffers are zeroed, the per-point offsets included, so no stale constant force
+survives — the point forces then follow, being a scatter of what was zeroed.
 """
 function refresh_particle_aero!(mode::AeroPressure, wing, points,
                                 va_point_b_vals; vsm_min_wind=0.5,
@@ -457,7 +457,6 @@ function refresh_particle_aero!(mode::AeroPressure, wing, points,
         fill!(mode.traction, 0.0)
         fill!(mode.traction_net, 0.0)
         accumulate_point_offset!(mode)
-        zero_point_forces!(wing, points)
         return nothing
     end
     update_vsm_wing_from_structure!(wing, points)
@@ -466,34 +465,9 @@ function refresh_particle_aero!(mode::AeroPressure, wing, points,
     freeze_traction_pattern!(mode, wing)
     any(!isfinite, mode.traction) && throw(AssertionError(
         "AeroPressure: non-finite traction pattern on wing $(wing.idx)"))
-    write_point_forces!(mode, wing, points)
     return nothing
 end
 
-"""
-    write_point_forces!(mode::AeroPressure, wing, points)
-
-Store each wing node's body-frame aero force in its `point.aero_force_b`: its share
-of every panel that scatters onto it, plus its constant offset. Rebuilt from the same
-scatter the equations carry, which reaches the points symbolically and so computes no
-per-point force of its own. This is the frozen pattern at the last refresh, not the
-live load the RHS re-derives from current geometry.
-"""
-function write_point_forces!(mode::AeroPressure, wing, points)
-    nodes = wing_nodes_of(wing, points)
-    for node in nodes
-        fill!(node.aero_force_b, 0.0)
-    end
-    sol = wing.vsm_solver.sol
-    for (panel, column, weight, _) in aero_scatter_entries(mode, wing, nodes)
-        @views nodes[column].aero_force_b .+= weight .* sol.f_body_3D[:, panel]
-    end
-    by_idx = Dict(node.idx => node for node in nodes)
-    for (idx, offset) in mode.point_offset
-        haskey(by_idx, idx) && (by_idx[idx].aero_force_b .+= offset)
-    end
-    return nothing
-end
 
 """
     contour_winding(section) -> Float64

--- a/src/aero_modes/pressure.jl
+++ b/src/aero_modes/pressure.jl
@@ -444,8 +444,10 @@ end
 Solve at the per-panel apparent wind the symbolic RHS uses
 ([`set_refined_panel_va!`](@ref)), freezing the induced velocity and the per-node
 surface traction pattern ([`freeze_traction_pattern!`](@ref)). Point forces are
-re-derived symbolically each RHS step. Below `vsm_min_wind` all frozen buffers are
-zeroed, the per-point offsets included, so no stale constant force survives.
+re-derived symbolically each RHS step; [`write_point_forces!`](@ref) additionally
+stores the frozen pattern's per-point load for logging and plotting. Below
+`vsm_min_wind` all frozen buffers are zeroed, the per-point offsets and the stored
+point forces included, so no stale constant force survives.
 """
 function refresh_particle_aero!(mode::AeroPressure, wing, points,
                                 va_point_b_vals; vsm_min_wind=0.5,
@@ -455,6 +457,7 @@ function refresh_particle_aero!(mode::AeroPressure, wing, points,
         fill!(mode.traction, 0.0)
         fill!(mode.traction_net, 0.0)
         accumulate_point_offset!(mode)
+        zero_point_forces!(wing, points)
         return nothing
     end
     update_vsm_wing_from_structure!(wing, points)
@@ -463,30 +466,33 @@ function refresh_particle_aero!(mode::AeroPressure, wing, points,
     freeze_traction_pattern!(mode, wing)
     any(!isfinite, mode.traction) && throw(AssertionError(
         "AeroPressure: non-finite traction pattern on wing $(wing.idx)"))
+    write_point_forces!(mode, wing, points)
     return nothing
 end
 
 """
-    aero_point_forces(mode::AeroPressure, wing, sys_struct)
+    write_point_forces!(mode::AeroPressure, wing, points)
 
-Each wing point's body-frame aero force: its share of every panel that scatters
-onto it, plus its constant offset. Rebuilt from the same scatter the equations
-use, since the traction reaches the points symbolically and never lands in a
-point's `aero_force_b`.
+Store each wing node's body-frame aero force in its `point.aero_force_b`: its share
+of every panel that scatters onto it, plus its constant offset. Rebuilt from the same
+scatter the equations carry, which reaches the points symbolically and so computes no
+per-point force of its own. This is the frozen pattern at the last refresh, not the
+live load the RHS re-derives from current geometry.
 """
-function aero_point_forces(mode::AeroPressure, wing, sys_struct)
+function write_point_forces!(mode::AeroPressure, wing, points)
+    nodes = wing_nodes_of(wing, points)
+    for node in nodes
+        fill!(node.aero_force_b, 0.0)
+    end
     sol = wing.vsm_solver.sol
-    points = wing_points(sys_struct, wing)
-    forces = Dict{Int, Vector{SimFloat}}()
-    for (panel, column, weight, _) in aero_scatter_entries(mode, wing, points)
-        total = get!(() -> zeros(SimFloat, 3), forces, points[column].idx)
-        total .+= weight .* Vector(sol.f_body_3D[:, panel])
+    for (panel, column, weight, _) in aero_scatter_entries(mode, wing, nodes)
+        @views nodes[column].aero_force_b .+= weight .* sol.f_body_3D[:, panel]
     end
+    by_idx = Dict(node.idx => node for node in nodes)
     for (idx, offset) in mode.point_offset
-        total = get!(() -> zeros(SimFloat, 3), forces, idx)
-        total .+= offset
+        haskey(by_idx, idx) && (by_idx[idx].aero_force_b .+= offset)
     end
-    return forces
+    return nothing
 end
 
 """

--- a/src/kernel_backend/assembly.jl
+++ b/src/kernel_backend/assembly.jl
@@ -304,9 +304,9 @@ all the state getter and the control setter need to find their values. A
 `wrench_instances` the load it feeds back (`0` for every other point).
 `aero_instances` holds each wing's aero instance and `twist_instances` each twist
 surface's, `0` where there is none. `aero_force_instances` holds each point's
-[`AeroPointForce`](@ref), `0` for a point with none. `inflow_instances` holds each point's
-[`AeroInflowPoint`](@ref), whose `va_b` output is the apparent wind the aero is
-solved on, and `0` for a point that has none.
+[`AeroPointForce`](@ref) and `inflow_instances` its [`AeroInflowPoint`](@ref), whose
+`va_b` output is the apparent wind the aero is solved on; `0` for a point with
+neither.
 """
 struct KernelModel{S, P}
     system::S

--- a/src/kernel_backend/assembly.jl
+++ b/src/kernel_backend/assembly.jl
@@ -303,7 +303,8 @@ all the state getter and the control setter need to find their values. A
 `BODY_STATIC` point has two: `point_instances` holds its kinematics and
 `wrench_instances` the load it feeds back (`0` for every other point).
 `aero_instances` holds each wing's aero instance and `twist_instances` each twist
-surface's, `0` where there is none. `inflow_instances` holds each point's
+surface's, `0` where there is none. `aero_force_instances` holds each point's
+[`AeroPointForce`](@ref), `0` for a point with none. `inflow_instances` holds each point's
 [`AeroInflowPoint`](@ref), whose `va_b` output is the apparent wind the aero is
 solved on, and `0` for a point that has none.
 """
@@ -321,6 +322,7 @@ struct KernelModel{S, P}
     aero_instances::Vector{Int}
     twist_instances::Vector{Int}
     inflow_instances::Vector{Int}
+    aero_force_instances::Vector{Int}
 end
 
 """
@@ -383,10 +385,11 @@ function assemble(sam; verbose = false)
     end
     flap_instances = add_flap_deltas!(builder, table, bindings, sam, body_instances)
     inflow_instances = zeros(Int, length(sys_struct.points))
+    aero_force_instances = zeros(Int, length(sys_struct.points))
     aero_instances = [add_wing_aero!(builder, table, bindings, sam, wing,
                                      body_instances, point_instances, flap_instances,
                                      twist_instances, wrench_instances,
-                                     inflow_instances)
+                                     inflow_instances, aero_force_instances)
                       for wing in sys_struct.wings]
 
     system = build_system(builder)
@@ -399,7 +402,7 @@ function assemble(sam; verbose = false)
     return KernelModel(system, u0, params, sync, point_instances,
                           wrench_instances, segment_instances, body_instances,
                           point_roles, segment_roles, aero_instances,
-                          twist_instances, inflow_instances)
+                          twist_instances, inflow_instances, aero_force_instances)
 end
 
 """
@@ -443,12 +446,12 @@ pose depends on the force it receives, so the schedule simply runs the structure
 then the wing frame, then the aero, then the derivatives.
 """
 function add_wing_aero!(builder, table, bindings, sam, wing, bodies, points, flaps,
-                        twists, wrenches, inflow_instances)
+                        twists, wrenches, inflow_instances, aero_force_instances)
     wing.dynamics_type == PARTICLE_DYNAMICS || return add_rigid_wing_aero!(
         builder, table, bindings, sam, wing, bodies, twists)
     supports_panel_decomposition(wing.aero) && return add_panel_wing_aero!(
         builder, table, bindings, sam, wing, bodies, points, flaps, wrenches,
-        inflow_instances)
+        inflow_instances, aero_force_instances)
     sys_struct = sam.sys_struct
     nodes = wing_points(sys_struct, wing)
     surfaces = wing_flap_surfaces(wing)
@@ -496,7 +499,8 @@ the wing's size and the other is not, which on a wing of any real size is the wh
 difference between a build that finishes and one that does not.
 """
 function add_panel_wing_aero!(builder, table, bindings, sam, wing, bodies, points,
-                              flaps, wrenches, inflow_instances)
+                              flaps, wrenches, inflow_instances,
+                              aero_force_instances)
     nodes = wing_points(sam.sys_struct, wing)
     body = bodies[wing.idx]
     inflow_points = add_aero_inflow_points!(builder, table, bindings, sam, nodes,
@@ -510,6 +514,9 @@ function add_panel_wing_aero!(builder, table, bindings, sam, wing, bodies, point
                               inflow_points, inflows, section_group, flaps)
     forces = add_aero_point_forces!(builder, table, bindings, sam, wing, nodes,
                                     inflow_points, body, points, wrenches)
+    for (node, instance) in zip(nodes, forces)
+        aero_force_instances[node.idx] = instance
+    end
     for (panel, node, force_weight, couple_weight) in
             aero_scatter_entries(wing.aero, wing, nodes)
         force_weight == 0 || connect!(builder, panels[panel], :force_out,

--- a/src/kernel_backend/state.jl
+++ b/src/kernel_backend/state.jl
@@ -345,8 +345,7 @@ drag_source(model::KernelModel, idx) =
     model.wrench_instances[idx]
 
 """The output slots of point `idx`'s body-frame aerodynamic force, or none when it
-has no [`AeroPointForce`](@ref) — a point outside a panel-decomposed wing. This is
-the same load the wing's `aero_force_b` readout is the sum of."""
+has no [`AeroPointForce`](@ref) — a point outside a panel-decomposed wing."""
 function aero_force_slots(model::KernelModel, idx)
     instance = model.aero_force_instances[idx]
     instance == 0 && return Int[]

--- a/src/kernel_backend/state.jl
+++ b/src/kernel_backend/state.jl
@@ -6,7 +6,7 @@
 # global slot, resolved once at assembly, so both are plain indexed loops.
 
 """
-    PointReadout(point, pos, vel, drag, wind, force, mass, va, va_frame)
+    PointReadout(point, pos, vel, drag, wind, force, mass, va, va_frame, aero)
 
 Where one point's results live: its `pos`/`vel` in the output buffer and its
 `total_drag`, `wind_vec` and `net_force` in the observable buffer — all three from
@@ -30,6 +30,7 @@ struct PointReadout
     mass::Int
     va::Vector{Int}
     va_frame::Int
+    aero::Vector{Int}
 end
 
 """
@@ -204,7 +205,8 @@ function KernelStateGetter(model::KernelModel, rhs, sys_struct)
                   observed_slots(system, drag_source(model, idx), :wind_vec),
                   observed_slots(system, drag_source(model, idx), :net_force),
                   mass_slot(system, drag_source(model, idx)),
-                  inflow_slots(model, idx), va_frame_body(sys_struct, idx))
+                  inflow_slots(model, idx), va_frame_body(sys_struct, idx),
+                  aero_force_slots(model, idx))
               for (idx, instance) in enumerate(model.point_instances)]
     segments = [SegmentReadout(idx,
                     only(buffer_slots(system, instance, :observables, :spring_force)),
@@ -342,6 +344,15 @@ drag_source(model::KernelModel, idx) =
     model.wrench_instances[idx] == 0 ? model.point_instances[idx] :
     model.wrench_instances[idx]
 
+"""The output slots of point `idx`'s body-frame aerodynamic force, or none when it
+has no [`AeroPointForce`](@ref) — a point outside a panel-decomposed wing. This is
+the same load the wing's `aero_force_b` readout is the sum of."""
+function aero_force_slots(model::KernelModel, idx)
+    instance = model.aero_force_instances[idx]
+    instance == 0 && return Int[]
+    return buffer_slots(model.system, instance, :outputs, :force_b)
+end
+
 """The output slots of point `idx`'s `va_b`, or none when it has no
 [`AeroInflowPoint`](@ref). This is the apparent wind the compiled model solves the
 aero on; reading it keeps the struct on the same value rather than a refit."""
@@ -404,6 +415,8 @@ function (getter::KernelStateGetter)(integrator, sys_struct::SystemStructure)
         copy_slots!(point.drag_force, scratch.observable, readout.drag)
         copy_slots!(point.wind_vec, scratch.observable, readout.wind)
         copy_slots!(point.force, scratch.observable, readout.force)
+        isempty(readout.aero) ||
+            copy_slots!(point.aero_force_b, scratch.output, readout.aero)
         readout.mass == 0 || (point.total_mass =
             point.extra_mass + scratch.input[readout.mass])
     end

--- a/src/model_management.jl
+++ b/src/model_management.jl
@@ -678,6 +678,23 @@ end
 
 
 """
+    reinit!(sam, integrator; solver=integrator.alg, kwargs...) -> (ODEIntegrator, Bool)
+
+Reset `integrator`, which is `sam`'s own, from the current `SystemStructure`.
+`solver` defaults to the one `integrator` was built with, so the reset stays on the
+right-hand side that is already compiled rather than forcing a second compilation
+at another Jacobian's element type. `kwargs` are those of
+[`reinit!`](@ref)`(sam, prob, solver; …)`.
+"""
+function reinit!(sam::SymbolicAWEModel,
+        integrator::OrdinaryDiffEqCore.ODEIntegrator;
+        solver = integrator.alg, kwargs...)
+    isnothing(sam.prob) && error("reinit!: $(sam.sys_struct.name) has no " *
+        "ODEProblem; call init! first.")
+    return reinit!(sam, sam.prob, solver; kwargs...)
+end
+
+"""
     reinit!(sam, prob, solver; kwargs...) -> (ODEIntegrator, Bool)
 
 Reset the ODE integrator from new initial conditions without rebuilding the

--- a/src/model_management.jl
+++ b/src/model_management.jl
@@ -2,6 +2,43 @@
 # SPDX-License-Identifier: LGPL-3.0-only
 
 """
+    carries_point_aero(sys_struct, point) -> Bool
+
+Whether `point`'s per-node aerodynamic force has to be read back out of the model: it
+is a node of a `PARTICLE_DYNAMICS` wing whose mode scatters panel loads, so the load
+exists only in the equations. A rigid wing's nodes carry the wing's own wrench
+instead, and a mode that precomputes the load ([`AeroDirect`](@ref)) already holds it
+in `aero_force_b` as the parameter the equations read — which is also the wing the
+`KernelBackend` builds no [`AeroPointForce`](@ref) for, so both backends cover the
+same nodes.
+"""
+function carries_point_aero(sys_struct, point)
+    point.is_wing_node || return false
+    body = sys_struct.bodies[point.wing_idx]
+    return is_wing(body) && body.dynamics_type == PARTICLE_DYNAMICS &&
+        supports_panel_decomposition(body.aero)
+end
+
+"""
+    point_aero_force_array(sys_struct, sys) -> Matrix{Num} or nothing
+
+The body-frame aerodynamic force of every point as one `3 x n_points` array to fetch,
+holding `aero_force_point_b` for the nodes that have one and a literal zero for the
+rest, so the whole thing scatters on the point index like the other per-point arrays.
+`nothing` when no wing writes per-node forces, which is when the variable does not
+exist. The zeros are constants in the generated function rather than equations in the
+system, so the points that carry no aero cost nothing to fetch.
+"""
+function point_aero_force_array(sys_struct, sys)
+    hasproperty(sys, :aero_force_point_b) || return nothing
+    any(carries_point_aero(sys_struct, point) for point in sys_struct.points) ||
+        return nothing
+    field = getproperty(sys, :aero_force_point_b)
+    return [carries_point_aero(sys_struct, point) ? Num(field[i, point.idx]) : Num(0)
+            for i in 1:3, point in sys_struct.points]
+end
+
+"""
     generate_prob_getters(sys_struct, sys)
 
 Generate getter and setter functions for the state variables of the full system model.
@@ -23,14 +60,17 @@ function generate_prob_getters(sys_struct, sys, param_registry=nothing,
 
     specs = NamedTuple[]
     if length(points) > 0
-        push!(specs, scatter_spec(ss -> ss.points,
-            sys.pos         => (c, v) -> copy_vec!(c.pos_w, v, c.idx),
-            sys.vel         => (c, v) -> copy_vec!(c.vel_w, v, c.idx),
-            sys.point_force => (c, v) -> copy_vec!(c.force, v, c.idx),
-            sys.va_point_b  => (c, v) -> copy_vec!(c.va_b, v, c.idx),
-            sys.wind_at_point => (c, v) -> copy_vec!(c.wind_vec, v, c.idx),
-            sys.point_mass  => (c, v) -> (c.total_mass = v[c.idx]; nothing),
-            sys.total_drag  => (c, v) -> copy_vec!(c.drag_force, v, c.idx)))
+        pairs = Pair[sys.pos         => (c, v) -> copy_vec!(c.pos_w, v, c.idx),
+                     sys.vel         => (c, v) -> copy_vec!(c.vel_w, v, c.idx),
+                     sys.point_force => (c, v) -> copy_vec!(c.force, v, c.idx),
+                     sys.va_point_b  => (c, v) -> copy_vec!(c.va_b, v, c.idx),
+                     sys.wind_at_point => (c, v) -> copy_vec!(c.wind_vec, v, c.idx),
+                     sys.point_mass  => (c, v) -> (c.total_mass = v[c.idx]; nothing),
+                     sys.total_drag  => (c, v) -> copy_vec!(c.drag_force, v, c.idx)]
+        aero_force = point_aero_force_array(sys_struct, sys)
+        isnothing(aero_force) || push!(pairs,
+            aero_force => (c, v) -> copy_vec!(c.aero_force_b, v, c.idx))
+        push!(specs, scatter_spec(ss -> ss.points, pairs...))
     end
     if length(pulleys) > 0
         push!(specs, scatter_spec(ss -> ss.pulleys,

--- a/src/model_management.jl
+++ b/src/model_management.jl
@@ -4,13 +4,10 @@
 """
     carries_point_aero(sys_struct, point) -> Bool
 
-Whether `point`'s per-node aerodynamic force has to be read back out of the model: it
-is a node of a `PARTICLE_DYNAMICS` wing whose mode scatters panel loads, so the load
-exists only in the equations. A rigid wing's nodes carry the wing's own wrench
-instead, and a mode that precomputes the load ([`AeroDirect`](@ref)) already holds it
-in `aero_force_b` as the parameter the equations read — which is also the wing the
-`KernelBackend` builds no [`AeroPointForce`](@ref) for, so both backends cover the
-same nodes.
+Whether `point`'s per-node aerodynamic force has to be read back out of the model:
+it is a node of a `PARTICLE_DYNAMICS` wing whose mode scatters panel loads, so the
+load exists only in the equations. This selects the same nodes the `KernelBackend`
+builds an [`AeroPointForce`](@ref) for.
 """
 function carries_point_aero(sys_struct, point)
     point.is_wing_node || return false
@@ -22,12 +19,11 @@ end
 """
     point_aero_force_array(sys_struct, sys) -> Matrix{Num} or nothing
 
-The body-frame aerodynamic force of every point as one `3 x n_points` array to fetch,
-holding `aero_force_point_b` for the nodes that have one and a literal zero for the
-rest, so the whole thing scatters on the point index like the other per-point arrays.
-`nothing` when no wing writes per-node forces, which is when the variable does not
-exist. The zeros are constants in the generated function rather than equations in the
-system, so the points that carry no aero cost nothing to fetch.
+The body-frame aerodynamic force of every point as one `3 x n_points` array to
+fetch, holding `aero_force_point_b` where a node has one and a literal zero
+elsewhere, so it scatters on the point index like the other per-point arrays.
+`nothing` when no wing writes per-node forces. The zeros are constants in the
+generated function, so a point carrying no aero costs nothing to fetch.
 """
 function point_aero_force_array(sys_struct, sys)
     hasproperty(sys, :aero_force_point_b) || return nothing
@@ -722,8 +718,8 @@ end
 
 Reset `integrator`, which is `sam`'s own, from the current `SystemStructure`.
 `solver` defaults to the one `integrator` was built with, so the reset stays on the
-right-hand side that is already compiled rather than forcing a second compilation
-at another Jacobian's element type. `kwargs` are those of
+compiled right-hand side instead of forcing a second compilation at another
+Jacobian's element type. `kwargs` are those of
 [`reinit!`](@ref)`(sam, prob, solver; …)`.
 """
 function reinit!(sam::SymbolicAWEModel,

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -215,10 +215,8 @@ function sim_reposition!(
             SymbolicAWEModels.reposition!(sys_struct.transforms, sys_struct)
             
             # Reinitialize the solver to handle the state discontinuity
-            local_prob = sam.prob
-            if local_prob isa ProbWithAttributes
-                SymbolicAWEModels.reinit!(sam, local_prob,
-                    FBDF(; autodiff = default_autodiff(sam.backend)))
+            if sam.prob isa ProbWithAttributes
+                SymbolicAWEModels.reinit!(sam, sam.integrator)
             end
 
             if prn

--- a/src/symbolic_awe_model.jl
+++ b/src/symbolic_awe_model.jl
@@ -312,9 +312,9 @@ end
 """
     write_aero_forces!(ss, sys_struct) -> ss
 
-Fill `ss.aero_force_x/y/z` with the aerodynamic force each point carries, world
-frame. A point's own `aero_force_b` holds it only for `PARTICLE_DYNAMICS` wing
-nodes, so a scattering mode is asked for its own distribution instead.
+Fill `ss.aero_force_x/y/z` with the aerodynamic force each wing node carries, world
+frame, from the `point.aero_force_b` each particle mode fills at refresh. A mode that
+stores none leaves its nodes at zero.
 """
 function write_aero_forces!(ss::SysState, sys_struct::SystemStructure)
     fill!(ss.aero_force_x, 0.0)
@@ -322,11 +322,11 @@ function write_aero_forces!(ss::SysState, sys_struct::SystemStructure)
     fill!(ss.aero_force_z, 0.0)
     for wing in sys_struct.wings
         rot = quaternion_to_rotation_matrix(wing.Q_b_to_w)
-        for (idx, force_b) in aero_point_forces(wing.aero, wing, sys_struct)
-            force = rot * force_b
-            ss.aero_force_x[idx] += force[1]
-            ss.aero_force_y[idx] += force[2]
-            ss.aero_force_z[idx] += force[3]
+        for point in wing_points(sys_struct, wing)
+            force = rot * point.aero_force_b
+            ss.aero_force_x[point.idx] += force[1]
+            ss.aero_force_y[point.idx] += force[2]
+            ss.aero_force_z[point.idx] += force[3]
         end
     end
     return ss

--- a/src/symbolic_awe_model.jl
+++ b/src/symbolic_awe_model.jl
@@ -312,9 +312,9 @@ end
 """
     write_aero_forces!(ss, sys_struct) -> ss
 
-Fill `ss.aero_force_x/y/z` with the aerodynamic force each wing node carries, world
-frame, from the `point.aero_force_b` each particle mode fills at refresh. A mode that
-stores none leaves its nodes at zero.
+Fill `ss.aero_force_x/y/z` with the world-frame aerodynamic force each wing node
+carries, from its `point.aero_force_b`. A mode that stores none leaves its nodes at
+zero.
 """
 function write_aero_forces!(ss::SysState, sys_struct::SystemStructure)
     fill!(ss.aero_force_x, 0.0)

--- a/src/system_structure/utilities.jl
+++ b/src/system_structure/utilities.jl
@@ -959,7 +959,7 @@ end
 
 Put each of `wing`'s nodes back to the body-frame aero force the log holds for it,
 rotating the logged world-frame `aero_force_x/y/z` by the frame just restored. A log
-written before those channels existed carries zeros and restores zeros.
+without those channels restores zeros.
 """
 function restore_point_aero_forces!(sys, wing, sys_state)
     length(sys_state.aero_force_x) == length(sys_state.X) || return nothing

--- a/src/system_structure/utilities.jl
+++ b/src/system_structure/utilities.jl
@@ -955,6 +955,25 @@ end
 # ==================== SYSSTATE INTEROP ==================== #
 
 """
+    restore_point_aero_forces!(sys, wing, sys_state)
+
+Put each of `wing`'s nodes back to the body-frame aero force the log holds for it,
+rotating the logged world-frame `aero_force_x/y/z` by the frame just restored. A log
+written before those channels existed carries zeros and restores zeros.
+"""
+function restore_point_aero_forces!(sys, wing, sys_state)
+    length(sys_state.aero_force_x) == length(sys_state.X) || return nothing
+    rot = quaternion_to_rotation_matrix(wing.Q_b_to_w)
+    for point in sys.points
+        (point.is_wing_node && point.wing_idx == wing.idx) || continue
+        point.aero_force_b .= rot' * [sys_state.aero_force_x[point.idx],
+                                      sys_state.aero_force_y[point.idx],
+                                      sys_state.aero_force_z[point.idx]]
+    end
+    return nothing
+end
+
+"""
     update_from_sysstate!(sys::SystemStructure, sys_state::SysState)
 
 Update the dynamic state of a `SystemStructure` from a `SysState` snapshot.
@@ -1057,12 +1076,12 @@ function update_from_sysstate!(sys::SystemStructure, sys_state::SysState{P}) whe
         # Set angular velocity to NaN (turn_rates in SysState, but need conversion)
         wing.ω_b .= sys_state.turn_rates
 
-        # Set aerodynamic quantities to NaN (to prevent plotting)
-        wing.aero_force_b .= NaN
-        wing.aero_moment_b .= NaN
-        wing.tether_force .= NaN
-        wing.tether_moment .= NaN
+        wing.aero_force_b .= sys_state.aero_force_b
+        wing.aero_moment_b .= sys_state.aero_moment_b
+        wing.tether_force .= sys_state.tether_induced_force
+        wing.tether_moment .= sys_state.tether_induced_moment
         wing.va_b .= NaN
+        restore_point_aero_forces!(sys, wing, sys_state)
         wing.v_wind .= sys_state.v_wind_kite
         wing.aoa = Float64(sys_state.AoA)
         wing.course = Float64(sys_state.course)

--- a/test/test_backend_parity.jl
+++ b/test/test_backend_parity.jl
@@ -27,6 +27,8 @@ if abspath(PROGRAM_FILE) == abspath(@__FILE__)
 end
 
 @isdefined(test_init!) || include(joinpath(@__DIR__, "util.jl"))
+@isdefined(write_pressure_fixture) ||
+    include(joinpath(@__DIR__, "pressure_fixture.jl"))
 
 using Test
 using SymbolicAWEModels
@@ -41,17 +43,20 @@ The 2plate kite on `backend`, built from `geometry` and initialised, with its
 struct scattered back out of the solved model. Each backend gets its own copy of
 the fixture so neither can read the other's model cache.
 """
-function parity_model(backend, geometry, root)
+function parity_model(backend, geometry, root; aero_mode=nothing, fixture=false)
     data_path = joinpath(root, string(nameof(typeof(backend))), "2plate_kite")
     mkpath(dirname(data_path))
     cp(joinpath(dirname(@__DIR__), "data", "2plate_kite"), data_path; force=true)
+    fixture && write_pressure_fixture(data_path)
     set_data_path(data_path)
     set = Settings("system.yaml")
     vsm_set = VortexStepMethod.VSMSettings(
         joinpath(data_path, "vsm_settings.yaml"); data_prefix=false)
     sys = load_sys_struct_from_yaml(joinpath(data_path, geometry);
                                     system_name="backend_parity", set=set,
-                                    vsm_set=vsm_set)
+                                    vsm_set=vsm_set,
+                                    (isnothing(aero_mode) ? () :
+                                     (; aero_mode=aero_mode()))...)
     sam = SymbolicAWEModel(set, sys; backend)
     init!(sam; prn=false, remake=true)
     update_sys_struct!(sam.prob, sam.integrator, sam.sys_struct)
@@ -110,15 +115,23 @@ end
 @testset "Backend read-back parity" begin
     data_path_before = get_data_path()
     root = mktempdir()
-    geometries = ("particle" => "particle_structural_geometry.yaml",
-                  "rigid" => "rigid_structural_geometry.yaml")
+    # `AeroPressure` is here as well as the default `AeroDirect` because the two
+    # reach `point.aero_force_b` by different routes: a mode that precomputes the
+    # load holds it as the parameter the equations read, while a panel-scattering
+    # mode leaves it in the equations and each backend has to read it back — the
+    # monolith through an observed array, the kernel through `AeroPointForce`
+    # slots. Only a scattering wing exercises that pair.
+    geometries = (("particle", "particle_structural_geometry.yaml", nothing, false),
+                  ("rigid", "rigid_structural_geometry.yaml", nothing, false),
+                  ("particle pressure", "particle_structural_geometry.yaml",
+                   () -> AeroPressure(), true))
 
-    for (name, geometry) in geometries
+    for (name, geometry, aero_mode, fixture) in geometries
         @testset "$name wing" begin
             kernel = parity_model(KernelBackend(), geometry,
-                                  joinpath(root, name))
+                                  joinpath(root, name); aero_mode, fixture)
             monolith = parity_model(MonolithBackend(), geometry,
-                                    joinpath(root, name))
+                                    joinpath(root, name); aero_mode, fixture)
 
             mismatches = struct_mismatches(kernel.sys_struct,
                                            monolith.sys_struct)

--- a/test/test_backend_parity.jl
+++ b/test/test_backend_parity.jl
@@ -115,12 +115,7 @@ end
 @testset "Backend read-back parity" begin
     data_path_before = get_data_path()
     root = mktempdir()
-    # `AeroPressure` is here as well as the default `AeroDirect` because the two
-    # reach `point.aero_force_b` by different routes: a mode that precomputes the
-    # load holds it as the parameter the equations read, while a panel-scattering
-    # mode leaves it in the equations and each backend has to read it back — the
-    # monolith through an observed array, the kernel through `AeroPointForce`
-    # slots. Only a scattering wing exercises that pair.
+    # Only `AeroPressure` scatters panel loads, exercising the read-back path.
     geometries = (("particle", "particle_structural_geometry.yaml", nothing, false),
                   ("rigid", "rigid_structural_geometry.yaml", nothing, false),
                   ("particle pressure", "particle_structural_geometry.yaml",

--- a/test/test_continuous_modes.jl
+++ b/test/test_continuous_modes.jl
@@ -147,10 +147,7 @@ group_means(groups, values) =
             next_step!(sam; dt=1e-4, vsm_interval=0)
             force_symbolic = copy(wing.aero_force_b)
 
-            # The per-node load lives only in the equations for these modes — no
-            # refresh computes it — so it reaches the struct by being read back out
-            # of the solved model. Summing it has to give the wing's own readout,
-            # which is that same sum taken inside the model.
+            # These modes leave the load in the equations; the struct reads it back.
             @testset "per-node force reaches the struct" begin
                 @test norm(force_symbolic) > 0.1
                 @test count(node -> !iszero(node.aero_force_b), nodes) > 0

--- a/test/test_continuous_modes.jl
+++ b/test/test_continuous_modes.jl
@@ -147,6 +147,17 @@ group_means(groups, values) =
             next_step!(sam; dt=1e-4, vsm_interval=0)
             force_symbolic = copy(wing.aero_force_b)
 
+            # The per-node load lives only in the equations for these modes — no
+            # refresh computes it — so it reaches the struct by being read back out
+            # of the solved model. Summing it has to give the wing's own readout,
+            # which is that same sum taken inside the model.
+            @testset "per-node force reaches the struct" begin
+                @test norm(force_symbolic) > 0.1
+                @test count(node -> !iszero(node.aero_force_b), nodes) > 0
+                @test isapprox(sum(node.aero_force_b for node in nodes),
+                               force_symbolic; rtol=1e-8)
+            end
+
             # Every per-panel intermediate must match VSM, not just the span sum:
             # a per-panel error that cancels spanwise is invisible in the total.
             # `panel_force_eqs` is evaluated on the panel's own geometry and


### PR DESCRIPTION
## Why

`reinit!(sam, prob, solver)` takes its solver as a required positional argument, and there is no way to ask `sam` what `init!` chose, so every caller re-derives it. Two callers got it wrong:

- **V3Kite's settling and replay** passed a bare `FBDF()`, whose default is `AutoForwardDiff`. `init!` builds with `default_autodiff(sam.backend)`, which the `MonolithBackend` answers with `AutoFiniteDiff`. So every `reinit!` discarded the compiled integrator and compiled the whole right-hand side again at `ForwardDiff.Dual` — exactly what `default_autodiff`'s docstring warns about. Settling the V3 PSM wing went from 863.7 s to 230.1 s on a warm model cache once it was handed the right solver, same trajectory.
- **`sim_reposition!`** had a milder form: it remembered `autodiff` and dropped `linsolve`, so on the `KernelBackend` it swapped the `KLUFactorization` for a dense one and rebuilt the integrator at every reposition.

## What

`reinit!(sam, integrator; solver=integrator.alg, kwargs...)`. The integrator is an argument because `reinit!` is also overloaded for `SystemStructure` and `Transform`s, so it is worth saying which one is being reset — and it gives the solver default an honest source rather than a second copy of `init!`'s choice. `sim_reposition!` uses it.

Version bumped to 0.15.2.

---

# Aerodynamic point loads

Two independent reasons the aerodynamic force arrows never appeared on a
particle wing. Separate commit, folded into this branch rather than a second
PR off the same base.

left to CI.

## The per-node load never reached the struct

`point.aero_force_b` was zero on all 156 wing nodes of an SK100. The Makie
extension tests exactly that field, finds it zero, and never reaches `arrows3d!`,
so a particle wing drew no aero arrows and the `aero_force_x/y/z` log channels
stayed empty.

The model already computes the load; nothing was reading it back. The monolith
declares `aero_force_point_b` and `aero_eqs!` equates it to the aero component's
`point_force`; the kernel gives every node an `AeroPointForce` whose `force_b`
output is what `WingAeroSum` sums into the wing's `aero_force_b`. Both backends now
scatter it into `point.aero_force_b`, so only the wiring differs — the monolith
fetches an observed array (a literal zero for points carrying no aero, so it still
indexes by point), the kernel copies the output slots beside the drag and net force
it already copies. On an SK100:

```
nonzero point.aero_force_b: 132 / 156      (24 nodes take no traction share)
sum nodes  = [1516.972, -129.4756, 2957.258]
wing total = [1516.972, -129.4756, 2957.258]
```

`supports_panel_decomposition` selects the wings, which is the same set on both
backends: `AeroDirect` precomputes the load and already holds it in `aero_force_b`
as the parameter its equations read, and is also the wing the kernel builds no
`AeroPointForce` for.

With the field filled, `aero_point_forces` and `stores_point_force` are both
unnecessary and removed. `stores_point_force` was defined, documented and called
from nowhere — it was the predicate that would have caught this. The docstring on
`frozen_point_force_component` claimed `AeroPressure` shared it, which it does not,
and that claim is the likely origin of the extension's assumption.

### Cost

SK100, 392 points, 156 wing nodes, `KernelBackend`, 200 steps:

| | `next_step!` median | `update_sys_struct!` median | nonzero |
|---|---|---|---|
| baseline, no per-node force | 32.625 ms | 319.41 µs | 0/156 |
| read-back | 33.906 ms | 350.60 µs | 132/156 |

About 30 µs a step, a thousandth of a 32 ms step. The step-level difference is
inside the run-to-run spread: a pair of runs differing by work that cannot make
anything faster still moved the `next_step!` median by 0.8 ms, so that is the
floor. The monolith pays differently — a larger observed function — and is not
measured here.

## Replay drew nothing, and `NaN` was why

`update_from_sysstate!` set the wing's aero and tether loads to `NaN` with the
comment "to prevent plotting". It does not prevent plotting: the extension skips a
load with `iszero`, and `iszero(NaN)` is `false`, so the `NaN` total was pushed
into the arrow list. The adaptive scale is shared:

```julia
max_force = maximum(norm.(aero_forces_raw))   # NaN
force_scale = vector_scale / max_force        # NaN
```

so one unset load blanked every aero arrow in the replay, including valid
per-point ones. `update_from_sysstate!` also never restored `point.aero_force_b`,
so replay had no per-point data regardless.

All four loads are now restored from the log — they are logged channels
(`aero_force_b`, `aero_moment_b`, `tether_induced_force/moment`) — and
`restore_point_aero_forces!` rotates the logged world-frame `aero_force_x/y/z`
back into the body frame per node, so a replay shows the loads of the frame it is
on rather than the last live values. Verified against a real log:

```
nonzero after restore = 132 / 156
max round-trip error  = 1.36e-5     (Float32 log precision)
wing.aero_force_b     = [3429.24, -561.136, 9650.39]   (was NaN)
```

`plot` additionally drops non-finite loads before scaling the rest, so a load a
mode leaves unset — `tether_force` on a particle wing, for instance — can no
longer blank the layer.

Tests: the per-node sum against the wing's own readout for both scattering modes
in `test_continuous_modes.jl`, and an `AeroPressure` case added to
`test_backend_parity.jl` — its field diff had only ever run the default
`AeroDirect` wing, where both backends left the field zero and agreed for the
wrong reason. Full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
