### PR TITLE
Let a model take its wind per point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # CHANGELOG
 
+## Unreleased
+
+### Added
+- Wind can be set per point. A `SystemStructure` now carries a `wind_mode`: the
+  default `ProfileWind()` is the height profile `set.profile_law` as before, and
+  `PerPointWind()` makes every `point.wind_vec` a parameter, settable between steps
+  (`load_sys_struct_from_yaml(path; wind_mode=PerPointWind())`, or the
+  `SystemStructure` keyword of the same name). Point drag and apparent wind read
+  their point's vector, a segment's tether drag the mean of its two endpoints, and a
+  wing its own `wing.wind_vec`; VSM panels keep interpolating their inflow from the
+  points, so a per-point wind reaches them unchanged. `init!` seeds every point and
+  wing with `set.wind_vec`, so a model that is never written to flies in a uniform
+  wind. `set.profile_law` keeps its `AtmosphericModels` meaning and is unused in this
+  mode. Only `PerPointWind` enters the model-cache hash, so existing models keep
+  their cached builds.
+
+### Changed
+- BREAKING: a wing's wind vector is `wing.wind_vec`, renamed from `wing.v_wind` to
+  match `point.wind_vec` and to stop reading as the scalar `set.v_wind`.
+
 ## v0.15.2 22-08-2026
 
 ### Added

--- a/docs/src/exported_functions.md
+++ b/docs/src/exported_functions.md
@@ -43,6 +43,41 @@ set_angular_damping
 calc_steady_torque
 ```
 
+## Wind
+
+Where a model takes its wind from is a [`WindMode`](@ref) on its
+`SystemStructure`. The default [`ProfileWind`](@ref) scales the ground wind
+`set.wind_vec` by the height profile `set.profile_law`. [`PerPointWind`](@ref)
+instead gives every point its own wind vector, settable between steps.
+
+```julia
+sys_struct = load_sys_struct_from_yaml(path; set, wind_mode=PerPointWind())
+sam = SymbolicAWEModel(set, sys_struct)
+init!(sam)
+for _ in 1:steps
+    for point in sam.sys_struct.points    # a gust field, refreshed every step
+        point.wind_vec .= my_wind_field(point.pos_w, sam.integrator.t)
+    end
+    sam.sys_struct.wings[1].wind_vec .= my_wind_field(...)
+    next_step!(sam)
+end
+```
+
+Each point's own drag and apparent wind read its `wind_vec` directly, and a
+segment's tether drag the mean of its two endpoints — the same averaging its
+drag already applies to their velocities. A wing reads its own `wing.wind_vec`,
+which is the wind a rigid wing's aerodynamics fly in; the per-point winds reach
+the VSM panels through the per-point inflow the panels already interpolate.
+`init!` seeds every point and wing with `set.wind_vec`, so a model that is never
+written to flies in a uniform wind.
+
+```@docs
+WindMode
+ProfileWind
+PerPointWind
+per_point_wind
+```
+
 ## Winch components
 
 The winch motor model is a pluggable [`AbstractWinchModel`](@ref) struct.

--- a/docs/src/private_functions.md
+++ b/docs/src/private_functions.md
@@ -38,6 +38,17 @@ SymbolicAWEModels.get_sys_struct_hash
 ```@docs
 SymbolicAWEModels.WindFactor
 SymbolicAWEModels.WindFactorReader
+SymbolicAWEModels.AbstractWindSource
+SymbolicAWEModels.ProfileWindSource
+SymbolicAWEModels.PrescribedWindSource
+SymbolicAWEModels.wind_mode
+SymbolicAWEModels.segment_wind_params
+SymbolicAWEModels.bind_segment_winds!
+SymbolicAWEModels.profile_wind_source
+SymbolicAWEModels.point_wind_source
+SymbolicAWEModels.segment_wind_source
+SymbolicAWEModels.wing_wind_source
+SymbolicAWEModels.seed_per_point_wind!
 SymbolicAWEModels.calc_angle_of_attack
 SymbolicAWEModels.calc_heading
 SymbolicAWEModels.calc_R_t_to_w

--- a/src/SymbolicAWEModels.jl
+++ b/src/SymbolicAWEModels.jl
@@ -88,6 +88,7 @@ export PrincipalFrameMethod, EIGEN_DECOMP, Y_ROTATION
 export AbstractAeroModel, AeroNone, AeroDirect, AeroLinearized, AeroPlate,
        ContinuousAero, AeroPressure
 export aero_component
+export WindMode, ProfileWind, PerPointWind, per_point_wind
 
 # --- High-Level Simulation Functions (Workers) ---
 export sim!, sim_reposition!

--- a/src/aero_modes/common.jl
+++ b/src/aero_modes/common.jl
@@ -778,7 +778,7 @@ function point_acceleration_w(point, wing_frame, wing_vel)
 end
 
 """
-    wing_kinematics_from_points!(wing, points, set, am;
+    wing_kinematics_from_points!(wing, points, set, am, wind_mode;
                                  zp1, zp2, yp1, yp2, origin, aero_points)
 
 Recompute a KINEMATIC/PARTICLE wing's kinematic state directly from the current point
@@ -789,10 +789,11 @@ reference is the weighted blend of its points. Writes the body frame `R_b_to_w`
 `ω_b` ([`body_frame_omega`](@ref)), the origin's acceleration `acc_w`
 ([`point_acceleration_w`](@ref)), the reported scalars
 ([`write_wing_scalars!`](@ref)), the wing apparent wind `va_b`, and each aero point's
-`va_b = R'·(wind(z)·wind_gnd − vel)` — the same quantities the monolith's
-`get_all_state` copies out of the integrator.
+`va_b = R'·(wind − vel)`, the wind coming from the height profile or, under
+[`PerPointWind`](@ref), from `point.wind_vec` and `wing.wind_vec`, which the caller
+owns — the same quantities the monolith's `get_all_state` copies out of the integrator.
 """
-function wing_kinematics_from_points!(wing, points, set, am;
+function wing_kinematics_from_points!(wing, points, set, am, wind_mode::WindMode;
         zp1, zp2, yp1, yp2, origin, aero_points,
         base_point = 0, twist_surfaces = nothing)
     pos_z1 = get_ref_position_from_points(points, zp1)
@@ -816,13 +817,14 @@ function wing_kinematics_from_points!(wing, points, set, am;
     for (idx, weight) in zip(origin.ids, origin.weights)
         wing.acc_w .+= weight .* point_acceleration_w(points[idx], R, wing.vel_w)
     end
-    wind_factor = WindFactor(am, set.profile_law)
-    wing.v_wind .= wind_factor(wing.pos_w[3]) .* set.wind_vec
-    wing.va_b .= R' * (wing.v_wind .- wing.vel_w .+ wing.wind_disturb)
+    profile = wind_mode isa PerPointWind ? nothing : WindFactor(am, set.profile_law)
+    isnothing(profile) || (wing.wind_vec .= profile(wing.pos_w[3]) .* set.wind_vec)
+    wing.va_b .= R' * (wing.wind_vec .- wing.vel_w .+ wing.wind_disturb)
     for point_idx in aero_points
         point = points[point_idx]
-        va_w = wind_factor(point.pos_w[3]) .* set.wind_vec .- point.vel_w
-        point.va_b .= R' * va_w
+        wind = isnothing(profile) ? point.wind_vec :
+            profile(point.pos_w[3]) .* set.wind_vec
+        point.va_b .= R' * (wind .- point.vel_w)
     end
     write_wing_scalars!(wing, points; base_point, twist_surfaces)
     return nothing

--- a/src/components/components.jl
+++ b/src/components/components.jl
@@ -26,35 +26,181 @@ remove_along(vector, axis) = vector .- (vector ⋅ axis) .* axis
 keep_along(vector, axis) = (vector ⋅ axis) .* axis
 
 """
+    WindMode
+
+Where a model takes its wind from, chosen once per [`SystemStructure`](@ref) through
+its `wind_mode` field and baked into the equations: [`ProfileWind`](@ref) or
+[`PerPointWind`](@ref). A further mode adds a `wind_source` method per consumer
+rather than a branch inside one.
+"""
+abstract type WindMode end
+
+"""
+    ProfileWind()
+
+The default wind mode: the ground wind `set.wind_vec` scaled by the height profile
+`set.profile_law` of `AtmosphericModels`, evaluated at each consumer's own height.
+"""
+struct ProfileWind <: WindMode end
+
+"""
+    PerPointWind()
+
+Wind mode in which every point carries its own wind vector: `point.wind_vec` becomes
+a parameter, settable between steps, instead of an output of the height profile. A
+segment takes the mean of its two endpoints' winds and a wing reads its own
+`wing.wind_vec`; `set.profile_law` is unused. `reinit!` seeds every point and wing
+with `set.wind_vec`, so a model that is never written to flies in a uniform wind.
+"""
+struct PerPointWind <: WindMode end
+
+"""The [`WindMode`](@ref) of the structure a build-time `params` view reads."""
+wind_mode(params) = params.reg.sys_struct.wind_mode
+
+"""Whether `sys_struct` takes its wind per point ([`PerPointWind`](@ref))."""
+per_point_wind(sys_struct) = sys_struct.wind_mode isa PerPointWind
+
+"""
+    AbstractWindSource
+
+Build-time source of the wind vector at one component. `source(height)` returns the
+world-frame wind as a length-3 expression, either the profile law's wind at that
+height ([`ProfileWindSource`](@ref)) or a wind the caller prescribes
+([`PrescribedWindSource`](@ref)). Which one a component gets is decided once, by the
+model's [`WindMode`](@ref), so the equations carry no runtime branch.
+"""
+abstract type AbstractWindSource end
+
+"""
+    ProfileWindSource(factor, ground)
+
+The wind of a height profile law: the ground wind ([`ground_wind_vec`](@ref)) scaled
+by the callable `wind_factor` parameter at the caller's height.
+"""
+struct ProfileWindSource{F, V} <: AbstractWindSource
+    factor::F
+    ground::V
+end
+(source::ProfileWindSource)(height) = source.factor(height) .* source.ground
+
+"""
+    PrescribedWindSource(wind)
+
+A wind expression that does not depend on height — under [`PerPointWind`](@ref) the
+component's own wind parameter, or an expression in the winds of the points it spans.
+The height it is asked for is ignored.
+"""
+struct PrescribedWindSource{V} <: AbstractWindSource
+    wind::V
+end
+(source::PrescribedWindSource)(height) = source.wind
+
+"""
+    profile_wind_source(params, ground)
+
+The height-profile wind source, registering the ground wind and the live
+`wind_factor` on `params`. The monolith passes its own `wind_vec_gnd` variable as
+`ground` so the ground wind keeps being written once for the whole system; `nothing`
+registers it here.
+"""
+profile_wind_source(params, ground) =
+    ProfileWindSource(param_computed!(params.reg, :wind_factor, WindFactorReader()),
+                      collect(isnothing(ground) ? ground_wind_vec(params) : ground))
+
+"""
+    point_wind_source(params, idx, ground=nothing)
+
+The wind source of point `idx`: its own `wind_vec` parameter under
+[`PerPointWind`](@ref), else the height profile.
+"""
+point_wind_source(params, idx, ground = nothing) =
+    point_wind_source(wind_mode(params), params, idx, ground)
+point_wind_source(::ProfileWind, params, idx, ground) =
+    profile_wind_source(params, ground)
+point_wind_source(::PerPointWind, params, idx, ground) =
+    PrescribedWindSource(collect(params.points[idx].wind_vec))
+
+"""
+    wing_wind_source(params, idx, ground=nothing)
+
+The wind source of wing `idx`: its own `wind_vec` parameter under
+[`PerPointWind`](@ref), else the height profile. This is the wind a rigid wing's
+aerodynamics fly in; the per-point winds reach the VSM panels through
+[`AeroInflowPoint`](@ref) instead.
+"""
+wing_wind_source(params, idx, ground = nothing) =
+    wing_wind_source(wind_mode(params), params, idx, ground)
+wing_wind_source(::ProfileWind, params, idx, ground) =
+    profile_wind_source(params, ground)
+wing_wind_source(::PerPointWind, params, idx, ground) =
+    PrescribedWindSource(collect(params.wings[idx].wind_vec))
+
+"""
+    segment_wind_source(params, idx, src_wind, dst_wind, ground=nothing)
+
+The wind source of segment `idx`: the mean of the winds at its two endpoints under
+[`PerPointWind`](@ref) — the same averaging its drag already applies to their
+velocities — else the height profile at its midpoint. `src_wind`/`dst_wind` are the
+endpoint winds as each backend addresses them and are unused under
+[`ProfileWind`](@ref).
+"""
+segment_wind_source(params, idx, src_wind, dst_wind, ground = nothing) =
+    segment_wind_source(wind_mode(params), params, idx, src_wind, dst_wind, ground)
+segment_wind_source(::ProfileWind, params, idx, src_wind, dst_wind, ground) =
+    profile_wind_source(params, ground)
+segment_wind_source(::PerPointWind, params, idx, src_wind, dst_wind, ground) =
+    PrescribedWindSource(0.5 .* (collect(src_wind) .+ collect(dst_wind)))
+
+"""
+    segment_wind_params(params, idx, with_drag) -> (wind_source, minted)
+
+The wind source a segment kernel uses and the parameters it has to declare for it.
+Under [`PerPointWind`](@ref) a drag-carrying segment mints `src_wind`/`dst_wind`,
+which `bind_segment_winds!` points at its two endpoints' `point.wind_vec` — the
+kernel is instanced over `:segments`, so the endpoints cannot be reached through the
+registry's per-instance index remapping. The monolith reads its endpoints'
+`wind_at_point` directly and calls [`segment_wind_source`](@ref) itself.
+"""
+function segment_wind_params(params, idx, with_drag)
+    wind_mode(params) isa PerPointWind ||
+        return segment_wind_source(params, idx, nothing, nothing), []
+    with_drag || return PrescribedWindSource(zeros(3)), []
+    src_wind = make_array_param(:src_wind, zeros(3))
+    dst_wind = make_array_param(:dst_wind, zeros(3))
+    return segment_wind_source(params, idx, src_wind, dst_wind), [src_wind, dst_wind]
+end
+
+"""
     point_acceleration(s, pos, vel, structural_force, mass, drag_coeff, area,
-                       world_damping, wind_gnd, wind_factor, g_earth)
+                       world_damping, wind_source, g_earth)
 
 `(; net_force, accel)` for a point mass: [`point_net_force`](@ref) and that per unit
 `mass`, minus world-frame damping.
 """
 function point_acceleration(s, pos, vel, structural_force, mass, drag_coeff, area,
-                            world_damping, wind_gnd, wind_factor, g_earth)
+                            world_damping, wind_source, g_earth)
     net_force = point_net_force(s, pos, vel, structural_force, mass, drag_coeff,
-                                area, wind_gnd, wind_factor, g_earth)
+                                area, wind_source, g_earth)
     return (; net_force, accel = net_force ./ mass .- world_damping .* vel)
 end
 
 """
-    point_net_force(s, pos, vel, structural_force, mass, drag_coeff, area, wind_gnd,
-                    wind_factor, g_earth)
+    point_net_force(s, pos, vel, structural_force, mass, drag_coeff, area,
+                    wind_source, g_earth)
 
 The physical force on a point: the structural force gathered from its segments plus
-its own aerodynamic drag against the wind at its height and gravity — the monolith's
-`point_force`. `structural_force` is the net force on the point (positive sign); each
-backend supplies it in its own aggregation convention. A clamped point reads it
-without moving, which is how an anchor's or a winch's load is read off. Both backends
-pass the registered `params.set.g_earth` as `g_earth` so gravity stays settable after
-construction; reading the setting here instead would bake it in at build time.
+its own aerodynamic drag against the wind its `wind_source` gives at its height and
+gravity — the monolith's `point_force`. `structural_force` is the net force on the
+point (positive sign); each backend supplies it in its own aggregation convention. A
+clamped point reads it without moving, which is how an anchor's or a winch's load is
+read off. Both backends pass the registered `params.set.g_earth` as `g_earth` so
+gravity stays settable after construction; reading the setting here instead would
+bake it in at build time.
 """
 function point_net_force(s, pos, vel, structural_force, mass, drag_coeff, area,
-                         wind_gnd, wind_factor, g_earth)
+                         wind_source::AbstractWindSource, g_earth)
     rho = air_density(s.am, pos[3])
-    va = wind_factor(pos[3]) .* wind_gnd .- vel
+    va = wind_source(pos[3]) .- vel
     drag = point_drag_force(va, rho, drag_coeff, area)
     gravity = [0.0, 0.0, -g_earth * mass]
     return structural_force .+ drag .+ gravity
@@ -65,19 +211,17 @@ end
 
 The shared DYNAMIC-particle parameters read from `params.points[idx]` — mass, drag,
 area and world-frame damping as the point's own struct fields — plus the registered
-gravity `g_earth` and the computed ground wind `wind_gnd` ([`ground_wind_vec`](@ref)).
-Returns a named tuple consumed by [`dynamic_point_dynamics`](@ref); each read
-registers the parameter on `params`, so gravity stays settable after construction.
+gravity `g_earth` and the point's [`point_wind_source`](@ref). Returns a named tuple
+consumed by [`dynamic_point_dynamics`](@ref); each read registers the parameter on
+`params`, so gravity stays settable after construction.
 """
 function point_particle_params(params, idx)
     point = params.points[idx]
-    wind_gnd = ground_wind_vec(params)
     return (; extra_mass = point.extra_mass, drag_coeff = point.drag_coeff,
             area = point.area, world_damping = point.world_frame_damping,
-            fix_sphere = point.fix_sphere, fix_static = point.fix_static, wind_gnd,
+            fix_sphere = point.fix_sphere, fix_static = point.fix_static,
             g_earth = params.set.g_earth,
-            wind_factor = param_computed!(params.reg, :wind_factor,
-                                          WindFactorReader()))
+            wind_source = point_wind_source(params, idx))
 end
 
 """
@@ -108,7 +252,7 @@ Shared body of the DYNAMIC point/pulley vertices: `D(pos)=vel`,
 function dynamic_point_dynamics(s, pos, vel, force, mass, pars, net_force)
     motion = point_acceleration(s, collect(pos), collect(vel), collect(force),
         mass, pars.drag_coeff, pars.area, collect(pars.world_damping),
-        collect(pars.wind_gnd), pars.wind_factor, pars.g_earth)
+        pars.wind_source, pars.g_earth)
     velocity, acceleration = confined_derivatives(pos, vel, motion.accel, pars)
     return [D.(collect(pos)) .~ velocity; D.(collect(vel)) .~ acceleration;
             collect(net_force) .~ motion.net_force]
@@ -133,31 +277,26 @@ end
 
 The spring-damper parameters read from `params.segments[idx]` (stiffness, damping,
 compression fraction, diameter, density as the segment's own struct fields), plus
-the global tether drag `cd_tether` (`params.set.cd_tether`) and the ground wind
-`wind_gnd` ([`ground_wind_vec`](@ref)) and the live `wind_factor`. With
-`with_drag=false` (the [`wing_structural_segment`](@ref) edge) `cd_tether` is a
-literal `0` and unused. `nonlinear` marks a callable `unit_stiffness` force law.
-Returns `(spring_named_tuple, wind_gnd, wind_factor)`; each read registers the
+the global tether drag `cd_tether` (`params.set.cd_tether`). With `with_drag=false`
+(the [`wing_structural_segment`](@ref) edge) `cd_tether` is a literal `0` and unused.
+`nonlinear` marks a callable `unit_stiffness` force law. Each read registers the
 parameter on `params`.
 """
 function segment_spring_params(params, idx; with_drag = true)
     seg = params.segments[idx]
     cd_tether = with_drag ? params.set.cd_tether : 0.0
-    wind_gnd = ground_wind_vec(params)
     nonlinear = !(params.reg.sys_struct.segments[idx].unit_stiffness isa Real)
-    spring = (; unit_stiffness = seg.unit_stiffness, unit_damping = seg.unit_damping,
-              compression_frac = seg.compression_frac,
-              compression_damping_frac = seg.compression_damping_frac,
-              diameter = seg.diameter,
-              density = seg.density, cd_tether, nonlinear)
-    wind_factor = param_computed!(params.reg, :wind_factor, WindFactorReader())
-    return spring, wind_gnd, wind_factor
+    return (; unit_stiffness = seg.unit_stiffness, unit_damping = seg.unit_damping,
+            compression_frac = seg.compression_frac,
+            compression_damping_frac = seg.compression_damping_frac,
+            diameter = seg.diameter,
+            density = seg.density, cd_tether, nonlinear)
 end
 
 """
     segment_load_terms(s, src_pos, src_vel, dst_pos, dst_vel, unit_stiffness,
                        unit_damping, compression_frac, compression_damping_frac,
-                       l0, diameter, density, cd_tether, wind_gnd, wind_factor;
+                       l0, diameter, density, cd_tether, wind_source;
                        with_drag=true, nonlinear=false, rest_len_rate=0.0)
 
 Every load term a segment produces, as a named tuple: the geometry (`segment_vec`,
@@ -166,8 +305,8 @@ and its vector `spring_vec`, the `half_mass` and `half_drag` each endpoint carri
 and the total `force_on_src`/`force_on_dst` in the positive force-on-point sign.
 With `nonlinear` the `unit_stiffness` is a callable force law of strain
 ([`segment_nonlinear_force`](@ref)) rather than a linear rate; with
-`with_drag = false` the tether drag is dropped entirely, so `cd_tether`/`wind_gnd`
-are unused.
+`with_drag = false` the tether drag is dropped entirely, so
+`cd_tether`/`wind_source` are unused.
 
 `rest_len_rate` is `d(l0)/dt` for a segment whose rest length is a state — a pulley
 leg or a winched tether member. The damper resists the rate of change of the extension
@@ -178,7 +317,8 @@ dampers still drive it, which lets the damping inject energy.
 function segment_load_terms(s, src_pos, src_vel, dst_pos, dst_vel,
                             unit_stiffness, unit_damping, compression_frac,
                             compression_damping_frac,
-                            l0, diameter, density, cd_tether, wind_gnd, wind_factor;
+                            l0, diameter, density, cd_tether,
+                            wind_source::AbstractWindSource;
                             with_drag = true, nonlinear = false,
                             rest_len_rate = 0.0)
     segment_vec, len, unit_vec, closing_vel =
@@ -195,7 +335,7 @@ function segment_load_terms(s, src_pos, src_vel, dst_pos, dst_vel,
         seg_pos_z = 0.5 * (src_pos[3] + dst_pos[3])
         rho = air_density(s.am, seg_pos_z)
         seg_vel = 0.5 .* (src_vel .+ dst_vel)
-        va = wind_factor(seg_pos_z) .* wind_gnd .- seg_vel
+        va = wind_source(seg_pos_z) .- seg_vel
         half_drag = 0.5 .*
             segment_perp_drag(va, unit_vec, rho, cd_tether, len * diameter)
     end
@@ -757,19 +897,18 @@ end
 """
     point_wind_eqs(s, params, idx, io)
 
-Bind `wind_vec` to the profile law's wind at the point's own height — the monolith's
-`wind_at_point`, scattered into `point.wind_vec` — and `total_drag` to the point's
-own aerodynamic drag against it plus the share its segments deliver, which the state
-getter scatters into `point.drag_force`.
+Bind `wind_vec` to the point's [`point_wind_source`](@ref) at its own height — the
+monolith's `wind_at_point`, scattered into `point.wind_vec` — and `total_drag` to the
+point's own aerodynamic drag against it plus the share its segments deliver, which
+the state getter scatters into `point.drag_force`.
 """
 function point_wind_eqs(s, params, idx, io)
     point = params.points[idx]
-    wind = param_computed!(params.reg, :wind_factor, WindFactorReader())
     height = collect(io.pos)[3]
     apparent = collect(io.wind_vec) .- collect(io.vel)
     own = point_drag_force(apparent, air_density(s.am, height),
                            point.drag_coeff, point.area)
-    return [collect(io.wind_vec) .~ wind(height) .* ground_wind_vec(params);
+    return [collect(io.wind_vec) .~ point_wind_source(params, idx)(height);
             collect(io.total_drag) .~ own .+ collect(io.drag_in)]
 end
 
@@ -808,7 +947,7 @@ function Anchor(s, params, idx; name)
         collect(io.vel) .~ zeros(3)
         collect(io.net_force) .~ point_net_force(s, collect(io.pos), collect(io.vel),
             collect(io.force_in), pars.extra_mass + io.mass_in, pars.drag_coeff,
-            pars.area, collect(pars.wind_gnd), pars.wind_factor, pars.g_earth)
+            pars.area, pars.wind_source, pars.g_earth)
         point_wind_eqs(s, params, idx, io)
     ]
     vars = [io.pos, io.vel, io.force_in, io.mass_in, io.drag_in, io.total_drag,
@@ -904,7 +1043,7 @@ function WinchAnchor(s, params, winch, idx; name)
         collect(io.vel) .~ zeros(3)
         collect(io.net_force) .~ point_net_force(s, collect(io.pos), collect(io.vel),
             collect(io.force_in), pars.extra_mass + io.mass_in, pars.drag_coeff,
-            pars.area, collect(pars.wind_gnd), pars.wind_factor, pars.g_earth)
+            pars.area, pars.wind_source, pars.g_earth)
         point_wind_eqs(s, params, idx, io)
         extra[3] ~ smooth_norm(collect(extra[1]))
         motor.vel ~ extra[2]
@@ -959,18 +1098,21 @@ end
 
 The equations every segment kernel shares: the shared [`segment_load_terms`](@ref)
 evaluated at `rest_len`, bound to the [`segment_variables`](@ref) outputs and diagnostics.
-Returns `(eqs, loads)`; `loads` carries the scalar and vector spring tension a
-pulley or tether segment emits on top of these. `rest_len_rate` is `d(rest_len)/dt`
-for the kernels whose rest length is driven by another component's state.
+Returns `(eqs, loads, wind_params)`; `loads` carries the scalar and vector spring
+tension a pulley or tether segment emits on top of these and `wind_params` the
+parameters [`segment_wind_params`](@ref) minted, which the kernel must declare.
+`rest_len_rate` is `d(rest_len)/dt` for the kernels whose rest length is driven by
+another component's state.
 """
 function segment_eqs(s, params, idx, io, rest_len; with_drag = true,
                      rest_len_rate = 0.0)
-    spring, wind, wind_factor = segment_spring_params(params, idx; with_drag)
+    spring = segment_spring_params(params, idx; with_drag)
+    wind_source, wind_params = segment_wind_params(params, idx, with_drag)
     loads = segment_load_terms(s, collect(io.src_pos), collect(io.src_vel),
         collect(io.dst_pos), collect(io.dst_vel), spring.unit_stiffness,
         spring.unit_damping, spring.compression_frac,
         spring.compression_damping_frac, rest_len, spring.diameter,
-        spring.density, spring.cd_tether, collect(wind), wind_factor;
+        spring.density, spring.cd_tether, wind_source;
         with_drag, nonlinear = spring.nonlinear, rest_len_rate)
     eqs = [
         collect(io.src_force) .~ loads.force_on_src
@@ -981,7 +1123,7 @@ function segment_eqs(s, params, idx, io, rest_len; with_drag = true,
         io.len ~ loads.len
         io.l0 ~ rest_len
     ]
-    return eqs, loads
+    return eqs, loads, wind_params
 end
 
 """
@@ -993,8 +1135,9 @@ type rather than a zeroed drag coefficient.
 """
 function SpringSegment(s, params, idx; name, with_drag = true)
     io = segment_variables()
-    eqs, _ = segment_eqs(s, params, idx, io, params.segments[idx].l0; with_drag)
-    return System(eqs, t, io.all, param_unknowns(params); name)
+    eqs, _, wind = segment_eqs(s, params, idx, io, params.segments[idx].l0;
+                               with_drag)
+    return System(eqs, t, io.all, [param_unknowns(params); wind]; name)
 end
 
 """
@@ -1019,12 +1162,13 @@ function PulleySegment(s, params, idx, pulley_idx; name)
     end
     side = make_param(:pulley_side, 1.0)
     sum_len = params.pulleys[pulley_idx].sum_len
-    eqs, loads = segment_eqs(s, params, idx, io,
+    eqs, loads, wind = segment_eqs(s, params, idx, io,
         ifelse(side > 0.0, extra[1], sum_len - extra[1]);
         rest_len_rate = ifelse(side > 0.0, extra[2], -extra[2]))
     push!(eqs, extra[3] ~ side * loads.spring)
     push!(eqs, extra[4] ~ 0.5 * loads.spring)
-    return System(eqs, t, [io.all; extra], [param_unknowns(params); side]; name)
+    return System(eqs, t, [io.all; extra],
+                  [param_unknowns(params); side; wind]; name)
 end
 
 """
@@ -1046,12 +1190,13 @@ function TetherSegment(s, params, idx; name)
         dst_tension(t)[1:3], [output = true]
     end
     count = make_param(:segment_count, 1.0)
-    eqs, loads = segment_eqs(s, params, idx, io, extra[1] / count;
-                             rest_len_rate = extra[2] / count)
+    eqs, loads, wind = segment_eqs(s, params, idx, io, extra[1] / count;
+                                   rest_len_rate = extra[2] / count)
     eqs = [eqs
            collect(extra[3]) .~ loads.spring_vec
            collect(extra[4]) .~ .-loads.spring_vec]
-    return System(eqs, t, [io.all; extra], [param_unknowns(params); count]; name)
+    return System(eqs, t, [io.all; extra],
+                  [param_unknowns(params); count; wind]; name)
 end
 
 """
@@ -1315,8 +1460,7 @@ come back separately because they are the other two quantities
 """
 function ride_load(s, params, idx, io; with_gravity)
     point = params.points[idx]
-    wind_factor = param_computed!(params.reg, :wind_factor, WindFactorReader())
-    wind = wind_factor(io.height) .* ground_wind_vec(params)
+    wind = point_wind_source(params, idx)(io.height)
     apparent = wind .- collect(io.vel)
     drag = point_drag_force(apparent, air_density(s.am, io.height),
                             point.drag_coeff, point.area)
@@ -1779,11 +1923,10 @@ function ParticleWingAero(s, params, idx; name)
     validate_aero_component(subsys, wing)
     orientation = reshape(collect(pose[2]), 3, 3)
     origin = collect(pose[1])
-    wind_factor = param_computed!(params.reg, :wind_factor, WindFactorReader())
-    wind_gnd = ground_wind_vec(params)
     heights = [collect(positions[k])[3] for k in 1:count]
-    apparent_winds = [orientation' * (wind_factor(collect(positions[k])[3]) .*
-                                      wind_gnd .- collect(velocities[k]))
+    apparent_winds = [orientation' *
+                      (point_wind_source(params, points[k].idx)(heights[k]) .-
+                       collect(velocities[k]))
                       for k in 1:count]
     wiring = particle_wing_aero_wiring(s, subsys; orientation, origin, positions,
                                        velocities, apparent_winds, heights)
@@ -1801,15 +1944,16 @@ function ParticleWingAero(s, params, idx; name)
 end
 
 """
-    AeroInflowPoint(s, params; name)
+    AeroInflowPoint(s, params, idx; name)
 
 What one structural point contributes to its wing's aerodynamics: its world `pos` and
 `vel` and the wing's pose in; its body-frame position, apparent wind and air density
 out. These are exactly the per-point quantities the `PARTICLE_DYNAMICS` branch of
-`aero_eqs!` builds, and none of them depends on which wing or which point it is — so
+`aero_eqs!` builds, and the only thing that distinguishes point `idx` from any other
+is the parameter its [`point_wind_source`](@ref) reads — remapped per instance — so
 one compiled kernel serves every aerodynamic point of every wing.
 """
-function AeroInflowPoint(s, params; name)
+function AeroInflowPoint(s, params, idx; name)
     io = @variables begin
         pos(t)[1:3], [input = true]
         vel(t)[1:3], [input = true]
@@ -1821,8 +1965,7 @@ function AeroInflowPoint(s, params; name)
     end
     position = collect(io[1])
     orientation = reshape(collect(io[4]), 3, 3)
-    wind_factor = param_computed!(params.reg, :wind_factor, WindFactorReader())
-    apparent = wind_factor(position[3]) .* ground_wind_vec(params) .- collect(io[2])
+    apparent = point_wind_source(params, idx)(position[3]) .- collect(io[2])
     eqs = [
         collect(io[5]) .~ orientation' * (position .- collect(io[3]))
         collect(io[6]) .~ orientation' * apparent
@@ -1993,14 +2136,13 @@ function WingAero(s, params, idx; name)
     orientation = reshape(collect(pose.pose_frame), 3, 3)
     origin = collect(pose.pose_pos)
     velocity = rigid_body_point_velocity(pose, origin .- collect(pose.pose_com))
-    wind_factor = param_computed!(params.reg, :wind_factor, WindFactorReader())
     wiring = rigid_wing_aero_wiring(s, subsys, wing;
         apparent_wind_b = collect(io[5]), height = origin[3],
         frame = collect(pose.pose_frame),
         omega_b = orientation' * collect(pose.pose_omega),
         twist_angles = twists, twist_rates = rates)
     eqs = [
-        collect(io[6]) .~ wind_factor(origin[3]) .* ground_wind_vec(params)
+        collect(io[6]) .~ wing_wind_source(params, idx)(origin[3])
         collect(io[5]) .~ orientation' * (collect(io[6]) .- velocity .+
                                           collect(params.wings[idx].wind_disturb))
         wiring.eqs
@@ -2294,8 +2436,7 @@ function WingNodePoint(s, params, idx; name, with_damping = true)
     mass = pars.extra_mass + io.mass_in
     motion = point_acceleration(s, collect(io.pos), collect(io.vel),
         collect(io.force_in), mass, pars.drag_coeff, pars.area,
-        collect(pars.world_damping), collect(pars.wind_gnd), pars.wind_factor,
-        pars.g_earth)
+        collect(pars.world_damping), pars.wind_source, pars.g_earth)
     accel = motion.accel
     with_damping && (accel = accel .- body_frame_damp_accel(io.vel,
         point.body_frame_damping, orientation, collect(extra[2])))

--- a/src/generate_system/create_sys.jl
+++ b/src/generate_system/create_sys.jl
@@ -197,7 +197,7 @@ function create_sys!(s::SymbolicAWEModel, system::SystemStructure;
     # 3. Segment equations (spring-damper forces, returns len and spring_force)
     eqs, len, spring_force = segment_eqs!(
         s, eqs, points, segments, pulleys, tethers, bodies, params;
-        pos, vel, wind_vec_gnd, spring_force_vec, drag_force, l0,
+        pos, vel, wind_vec_gnd, wind_at_point, spring_force_vec, drag_force, l0,
         pulley_len, pulley_vel, tether_len, tether_vel
     )
 

--- a/src/generate_system/point_eqs.jl
+++ b/src/generate_system/point_eqs.jl
@@ -145,7 +145,6 @@ function point_eqs!(s, eqs, defaults, points, segments, twist_surfaces, wings, p
                     body_force, body_moment, body_pos_w, body_com_w, body_R_b_to_w,
                     body_com_vel, body_ω_b)
 
-    wind_factor = param_computed!(params.reg, :wind_factor, WindFactorReader())
     wind_gnd = collect(wind_vec_gnd)
     for point in points
         F::Vector{Num} = zeros(Num, 3)
@@ -187,6 +186,7 @@ function point_eqs!(s, eqs, defaults, points, segments, twist_surfaces, wings, p
 
         drag_coeff = params.points[point.idx].drag_coeff
         area = params.points[point.idx].area
+        wind_source = point_wind_source(params, point.idx, wind_gnd)
         drag_rhs = point_drag_force(collect(va_point_w[:, point.idx]),
             air_density(s.am, height[point.idx]), drag_coeff, area)
         va_point_b_rhs = isnothing(wing_idx_for_transform) ? zeros(3) :
@@ -194,8 +194,7 @@ function point_eqs!(s, eqs, defaults, points, segments, twist_surfaces, wings, p
         eqs = [
             eqs
             height[point.idx] ~ max(0.0, pos[3, point.idx])
-            wind_at_point[:, point.idx] ~
-                wind_factor(pos[3, point.idx]) * wind_vec_gnd
+            wind_at_point[:, point.idx] ~ wind_source(pos[3, point.idx])
             va_point_w[:, point.idx] ~
                 wind_at_point[:, point.idx] - vel[:, point.idx]
             va_point_b[:, point.idx] ~ va_point_b_rhs
@@ -225,8 +224,8 @@ function point_eqs!(s, eqs, defaults, points, segments, twist_surfaces, wings, p
                 collect(pos[:, point.idx]), collect(vel[:, point.idx]),
                 collect(spring_sum_force[:, point.idx]) .+ aero_force_w .+
                     collect(disturb_force[:, point.idx]),
-                carries_gravity ? mass : 0.0, drag_coeff, area, wind_gnd,
-                wind_factor, carries_gravity ? params.set.g_earth : 0.0)
+                carries_gravity ? mass : 0.0, drag_coeff, area, wind_source,
+                carries_gravity ? params.set.g_earth : 0.0)
         ]
 
         # EXCEPTION to the anchor rule: a wing node on a RIGID_DYNAMICS wing is

--- a/src/generate_system/scalar_eqs.jl
+++ b/src/generate_system/scalar_eqs.jl
@@ -25,7 +25,6 @@ function scalar_eqs!(
     R_v_to_w, pos
 )
     (; wings) = s.sys_struct
-    wind_factor = param_computed!(params.reg, :wind_factor, WindFactorReader())
     @variables begin
         # Body frame axes and apparent wind (column-major: [1:3, wing_idx])
         e_x(t)[1:3, eachindex(wings)]
@@ -43,7 +42,8 @@ function scalar_eqs!(
             e_y[:, wing.idx] ~ R_b_to_w[:, 2, wing.idx]
             e_z[:, wing.idx] ~ R_b_to_w[:, 3, wing.idx]
             wind_vel_wing[:, wing.idx] ~
-                wind_factor(wing_pos[3, wing.idx]) * wind_vec_gnd
+                wing_wind_source(params, wing.idx, wind_vec_gnd)(
+                    wing_pos[3, wing.idx])
             wind_disturb[:, wing.idx] ~ params.wings[wing.idx].wind_disturb
             va_wing[:, wing.idx] ~
                 wind_vel_wing[:, wing.idx] - wing_vel[:, wing.idx] +

--- a/src/generate_system/segment_eqs.jl
+++ b/src/generate_system/segment_eqs.jl
@@ -65,8 +65,8 @@ end
 
 """
     segment_eqs!(s, eqs, points, segments, pulleys, tethers, bodies, params;
-                 pos, vel, wind_vec_gnd, spring_force_vec, drag_force, l0,
-                 pulley_len, pulley_vel, tether_len, tether_vel)
+                 pos, vel, wind_vec_gnd, wind_at_point, spring_force_vec,
+                 drag_force, l0, pulley_len, pulley_vel, tether_len, tether_vel)
 
 Generate equations for segment spring-damper forces and aerodynamic drag.
 
@@ -83,6 +83,8 @@ as well, keeping only the geometry.
 - `points`, `segments`, `pulleys`, `tethers`, `bodies`: System components.
 - `pos`, `vel`: Symbolic point state variables.
 - `wind_vec_gnd`: Symbolic ground-level wind vector.
+- `wind_at_point`: Per-point wind, which a [`PerPointWind`](@ref) segment averages
+  over its two endpoints instead of evaluating a height profile at its midpoint.
 - `spring_force_vec`, `drag_force`, `l0`: Pre-declared segment force variables.
 - `pulley_len`, `tether_len`: Symbolic state variables for pulley and tether lengths.
 - `pulley_vel`, `tether_vel`: Their rates, which a moving rest length's damper reads
@@ -94,7 +96,7 @@ as well, keeping only the geometry.
 """
 function segment_eqs!(s, eqs, points, segments,
                       pulleys, tethers, bodies,
-                      params; pos, vel, wind_vec_gnd,
+                      params; pos, vel, wind_vec_gnd, wind_at_point,
                       spring_force_vec, drag_force, l0,
                       pulley_len, pulley_vel, tether_len, tether_vel)
     @variables begin
@@ -141,11 +143,13 @@ function segment_eqs!(s, eqs, points, segments,
             continue
         end
 
-        spring, _, wind_factor = segment_spring_params(params, idx; with_drag)
+        spring = segment_spring_params(params, idx; with_drag)
+        wind_source = segment_wind_source(params, idx, wind_at_point[:, src],
+                                          wind_at_point[:, dst], wind_gnd)
         loads = segment_load_terms(s, src_pos, src_vel, dst_pos, dst_vel,
             spring.unit_stiffness, spring.unit_damping, spring.compression_frac,
             spring.compression_damping_frac, l0[idx], spring.diameter,
-            spring.density, spring.cd_tether, wind_gnd, wind_factor;
+            spring.density, spring.cd_tether, wind_source;
             with_drag, nonlinear = spring.nonlinear, rest_len_rate)
         eqs = [
             eqs

--- a/src/kernel_backend/assembly.jl
+++ b/src/kernel_backend/assembly.jl
@@ -530,17 +530,20 @@ end
     add_aero_inflow_points!(builder, table, bindings, sam, nodes, points, body)
 
 One [`AeroInflowPoint`](@ref) per structural point of a wing, wired from that point's
-kinematics and its wing body's pose. The kernel reads no per-component field, so every
-point of every wing shares it. Returns the instances, indexed as `nodes` is.
+kinematics and its wing body's pose. The only per-component field the kernel reads is
+the point's prescribed wind, remapped per instance, so every point of every wing
+shares it. Returns the instances, indexed as `nodes` is.
 """
 function add_aero_inflow_points!(builder, table, bindings, sam, nodes, points, body)
-    entry = kernel!(builder, table, sam, :aero_inflow_point, 0,
-                    params -> AeroInflowPoint(sam, params; name = :aero_inflow_point),
+    source = first(nodes).idx
+    entry = kernel!(builder, table, sam, :aero_inflow_point, source,
+                    params -> AeroInflowPoint(sam, params, source;
+                                              name = :aero_inflow_point),
                     AERO_INFLOW_POINT_INPUTS, AERO_INFLOW_POINT_OUTPUTS)
     instances = Int[]
     for node in nodes
         instance = add_instance!(builder, entry.index)
-        push!(bindings, (instance, entry, Dict{Symbol, Int}()))
+        push!(bindings, (instance, entry, Dict(:points => node.idx)))
         connect!(builder, points[node.idx], :pos, instance, :pos)
         connect!(builder, points[node.idx], :vel, instance, :vel)
         connect!(builder, body, :pos, instance, :wing_pos)
@@ -1193,6 +1196,7 @@ function bind_params(system, sys_struct, bindings, segment_roles, segment_instan
         end
     end
     retarget_tether_rest_lengths!(readers, segment_roles)
+    bind_segment_winds!(slots, readers, system, sys_struct, segment_instances)
     sync = KernelParamSync(group_readers(slots, readers),
                            group_callables(callable_targets, callable_readers))
     return KernelParams(numeric, callables), sync
@@ -1216,6 +1220,32 @@ function callable_store(system)
         defaults = Tuple(system.kernels[k].callable_defaults)
         fill(defaults, counts[k])
     end
+end
+
+"""
+    bind_segment_winds!(slots, readers, system, sys_struct, segment_instances)
+
+Point each segment's `src_wind`/`dst_wind` parameters at its two endpoints'
+`point.wind_vec`, which is how a [`PerPointWind`](@ref) segment reads the wind of the
+points it spans: a segment kernel is instanced over `:segments`, so its endpoints
+cannot both be reached through the registry's per-instance index remapping.
+[`segment_wind_params`](@ref) mints these parameters, so nothing else binds them; a
+segment without tether drag has none.
+"""
+function bind_segment_winds!(slots, readers, system, sys_struct, segment_instances)
+    per_point_wind(sys_struct) || return nothing
+    for (idx, instance) in enumerate(segment_instances)
+        kernel = system.kernels[system.instances[instance].kernel]
+        has_slot(kernel.params, :src_wind) || continue
+        endpoints = sys_struct.segments[idx].point_idxs
+        for (endpoint, name) in zip(endpoints, (:src_wind, :dst_wind))
+            for (k, slot) in enumerate(buffer_slots(system, instance, :params, name))
+                push!(slots, slot)
+                push!(readers, PathReader((:points, endpoint, :wind_vec, k)))
+            end
+        end
+    end
+    return nothing
 end
 
 """

--- a/src/kernel_backend/state.jl
+++ b/src/kernel_backend/state.jl
@@ -137,7 +137,7 @@ end
 the quantities the struct carries: its
 lumped body-frame `aero_force_b`/`aero_moment_b`, and — for a rigid wing, whose
 apparent wind the component computes rather than the getter — its `va_b` and
-`v_wind`. A name the component does not observe gets no slots and is left alone.
+`wind_vec`. A name the component does not observe gets no slots and is left alone.
 """
 struct WingAeroReadout
     wing::Int
@@ -471,7 +471,7 @@ function (getter::KernelStateGetter)(integrator, sys_struct::SystemStructure)
         copy_slots!(wing.aero_force_b, scratch.observable, readout.force)
         copy_slots!(wing.aero_moment_b, scratch.observable, readout.moment)
         copy_slots!(wing.va_b, scratch.observable, readout.apparent)
-        copy_slots!(wing.v_wind, scratch.observable, readout.wind)
+        copy_slots!(wing.wind_vec, scratch.observable, readout.wind)
     end
     for readout in getter.kinematic
         wing = sys_struct.bodies[readout.body]
@@ -479,8 +479,8 @@ function (getter::KernelStateGetter)(integrator, sys_struct::SystemStructure)
         base_point = (wing.transform_idx != 0 &&
                       wing.transform_idx <= length(transforms)) ?
             transforms[wing.transform_idx].base_point_idx : 0
-        wing_kinematics_from_points!(wing,
-            sys_struct.points, sys_struct.set, sys_struct.am;
+        wing_kinematics_from_points!(wing, sys_struct.points, sys_struct.set,
+            sys_struct.am, sys_struct.wind_mode;
             zp1 = readout.z1, zp2 = readout.z2, yp1 = readout.y1,
             yp2 = readout.y2, origin = readout.origin,
             aero_points = readout.aero_points, base_point,

--- a/src/model_management.jl
+++ b/src/model_management.jl
@@ -106,7 +106,7 @@ function generate_prob_getters(sys_struct, sys, param_registry=nothing,
         # Wing rigid-body state is synced via the embedded body in the bodies spec below.
         push!(specs, scatter_spec(ss -> ss.wings,
             sys.va_wing_b        => (c, v) -> copy_vec!(c.va_b, v, c.idx),
-            sys.wind_vel_wing    => (c, v) -> copy_vec!(c.v_wind, v, c.idx),
+            sys.wind_vel_wing    => (c, v) -> copy_vec!(c.wind_vec, v, c.idx),
             sys.aero_force_b     => (c, v) -> copy_vec!(c.aero_force_b, v, c.idx),
             sys.aero_moment_b    => (c, v) -> copy_vec!(c.aero_moment_b, v, c.idx),
             sys.elevation        => (c, v) -> (c.elevation = v[c.idx]; nothing),
@@ -791,8 +791,8 @@ This is used to check if a cached compiled model is still valid.
 
 Anything read back from a struct at sync time stays out, so one build serves a sweep
 over it. That is every numeric setting the equations use — `:g_earth`, `:wind_vec`,
-`:cd_tether`, `:v_wind`, `:profile_law`, initial conditions — since each enters as a
-flat parameter `sync_params!` refreshes from `sys_struct.set`, not as a literal.
+`:cd_tether`, `:v_wind`, the profile law, initial conditions — since each enters
+as a flat parameter `sync_params!` refreshes from `sys_struct.set`, not as a literal.
 
 # Runtime Fields (don't affect compilation, excluded from hash):
 - `:profile_law`: Wind profile law (evaluated at runtime via symbolic function)
@@ -826,6 +826,9 @@ Includes all structural properties that affect the symbolic equations:
 - Winch configuration
 - Wing topology, connectivity, aerodynamic model type (RIGID_DYNAMICS vs PARTICLE_DYNAMICS), and aero mode
 - Transform hierarchy
+- The wind mode, which decides whether the wind is a height profile or a per-point
+  parameter. Only [`PerPointWind`](@ref) enters the hash, so structures on the
+  default [`ProfileWind`](@ref) keep the cached models they already have.
 
 Excludes runtime-configurable properties like masses, lengths, stiffnesses.
 """
@@ -879,6 +882,7 @@ function get_sys_struct_hash(sys_struct::SystemStructure)
             origin_hash(wing.origin))
         push!(data_parts, wing_data)
     end
+    per_point_wind(sys_struct) && push!(data_parts, ("wind_mode", :per_point))
     for transform in transforms
         push!(data_parts, ("transform", transform.idx, transform.wing_idx, transform.rot_point_idx,
                         transform.base_point_idx, transform.base_transform_idx))

--- a/src/symbolic_awe_model.jl
+++ b/src/symbolic_awe_model.jl
@@ -373,7 +373,7 @@ function update_sys_state!(ss::SysState, sam::SymbolicAWEModel, zoom=1.0)
         ss.course = wing.course
         # Apparent Wind and Aerodynamics
         ss.v_app = norm(wing.va_b)
-        ss.v_wind_kite .= wing.v_wind
+        ss.v_wind_kite .= wing.wind_vec
         # Calculate AoA and Side Slip from apparent wind in body frame
         if ss.v_app > 1e-6 # Avoid division by zero
             ss.AoA = calc_aoa(wing.aero, wing)

--- a/src/system_structure/rigid_body.jl
+++ b/src/system_structure/rigid_body.jl
@@ -107,7 +107,8 @@ mutable struct Body{A<:AbstractAeroModel, D<:WingDynamics}
     const wind_disturb::KVec3
     drag_frac::SimFloat
     const va_b::KVec3
-    const v_wind::KVec3
+    "Wind velocity at the wing, world frame [m/s]: a height-profile output, or the settable input under `PerPointWind`."
+    const wind_vec::KVec3
     const aero_force_b::KVec3
     const aero_moment_b::KVec3
     const tether_moment::KVec3

--- a/src/system_structure/system_structure_core.jl
+++ b/src/system_structure/system_structure_core.jl
@@ -53,6 +53,8 @@ mutable struct SystemStructure{J<:ElasticJoint}
     stabilize::Bool
     fix_wing::Bool
     vsm_set::Union{Nothing, VortexStepMethod.VSMSettings}
+    "Where the wind comes from: [`ProfileWind`](@ref) or [`PerPointWind`](@ref)."
+    wind_mode::WindMode
 end
 
 function Base.getproperty(sys::SystemStructure, sym::Symbol)
@@ -889,6 +891,8 @@ of the same structural shape should share one.
 # Keyword Arguments
 - `points`, `twist_surfaces`, `segments`, etc.: Vectors of the system components.
 - `vsm_set`: `VSMSettings` for VSM wings; read from `vsm_settings.yaml` when omitted.
+- `wind_mode::WindMode=ProfileWind()`: [`PerPointWind`](@ref) makes every point's
+  `wind_vec` a settable parameter instead of a height-profile output.
 - `ignore_l0::Bool=false`: Recompute every segment `l0` from the CAD geometry.
 - `prn::Bool=true`: If true, print info messages about auto-generated components.
 
@@ -909,6 +913,7 @@ function SystemStructure(name, set;
         timoshenko_joints=TimoshenkoJoint[],
         ignore_l0::Bool=false,
         vsm_set=nothing,
+        wind_mode::WindMode=ProfileWind(),
         prn::Bool=true,
     )
     # Load VSMSettings if not provided and VSM wings exist
@@ -1134,7 +1139,7 @@ function SystemStructure(name, set;
         NamedCollection{Body}(wing_bodies, build_name_dict(wing_bodies)),
         NamedCollection{eltype(elastic_joints)}(elastic_joints, elastic_joint_names_dict),
         NamedCollection{TimoshenkoJoint}(timoshenko_joints, timoshenko_joint_names_dict),
-        AtmosphericModel(set), false, false, vsm_set)
+        AtmosphericModel(set), false, false, vsm_set, wind_mode)
     reinit!(sys_struct, set; prn)
 
     # Panel→flap twist_surface map (structural; needs placed bodies + built panels).

--- a/src/system_structure/types.jl
+++ b/src/system_structure/types.jl
@@ -293,7 +293,7 @@ mutable struct Point
     const drag_force::KVec3
     "Apparent velocity in body frame [m/s] (VSM per-point)."
     const va_b::KVec3
-    "Wind velocity at the point's own height, world frame [m/s]."
+    "Wind velocity at the point, world frame [m/s]: a height-profile output, or the settable input under `PerPointWind`."
     const wind_vec::KVec3
     "Dynamics type (DYNAMIC, STATIC, BODY_STATIC, KINEMATIC)."
     const type::DynamicsType

--- a/src/system_structure/utilities.jl
+++ b/src/system_structure/utilities.jl
@@ -680,6 +680,24 @@ function apply_tether_init_forces!(sys_struct::SystemStructure)
     end
 end
 
+"""
+    seed_per_point_wind!(sys_struct::SystemStructure)
+
+Give every point and every wing the ground wind `set.wind_vec` as its own wind, so a
+[`PerPointWind`](@ref) model that is never written to flies in the uniform wind the
+settings describe. Called from `reinit!`; from then on these winds belong to the
+caller, who writes them between steps.
+"""
+function seed_per_point_wind!(sys_struct::SystemStructure)
+    for point in sys_struct.points
+        point.wind_vec .= sys_struct.set.wind_vec
+    end
+    for wing in sys_struct.wings
+        wing.wind_vec .= sys_struct.set.wind_vec
+    end
+    return nothing
+end
+
 # ==================== REINIT! FOR SYSTEM STRUCTURE ==================== #
 
 """
@@ -786,18 +804,24 @@ function reinit!(sys_struct::SystemStructure, set::Settings;
     # Compute per-wing wind from settings
     wind_vec_gnd = set.wind_vec
 
-    wind_factor = WindFactor(sys_struct.am, sys_struct.set.profile_law)
+    if per_point_wind(sys_struct)
+        seed_per_point_wind!(sys_struct)
+    else
+        wind_factor = WindFactor(sys_struct.am, set.profile_law)
+        for wing in wings
+            # Calculate wind at wing position using atmospheric model
+            wing.wind_vec .= wind_factor(wing.pos_w[3]) * wind_vec_gnd
+        end
+    end
     for wing in wings
-        # Calculate wind at wing position using atmospheric model
-        wing.v_wind .= wind_factor(wing.pos_w[3]) * wind_vec_gnd
-
         R_b_to_w = wing.R_b_to_w::Matrix{SimFloat}
         if wing.dynamics_type == PARTICLE_DYNAMICS
-            va_wing_w = wing.v_wind - wing.vel_w + wing.wind_disturb
+            va_wing_w = wing.wind_vec - wing.vel_w + wing.wind_disturb
             wing.va_b .= R_b_to_w' * va_wing_w
         else
             # Initialize the aero operating point from the initial wind
-            init_aero_state!(wing.aero, wing, R_b_to_w' * wind_vec_gnd)
+            init_aero_state!(wing.aero, wing, R_b_to_w' *
+                (per_point_wind(sys_struct) ? wing.wind_vec : wind_vec_gnd))
         end
     end
 
@@ -1019,7 +1043,7 @@ function update_from_sysstate!(sys::SystemStructure, sys_state::SysState{P}) whe
         wing.tether_moment .= sys_state.tether_induced_moment
         wing.va_b .= NaN
         restore_point_aero_forces!(sys, wing, sys_state)
-        wing.v_wind .= sys_state.v_wind_kite
+        wing.wind_vec .= sys_state.v_wind_kite
         wing.aoa = Float64(sys_state.AoA)
         wing.course = Float64(sys_state.course)
         wing.acc_w .= 0.0

--- a/src/yaml_loader.jl
+++ b/src/yaml_loader.jl
@@ -692,10 +692,11 @@ end
 
 Build a `SystemStructure` from a component-based structural
 YAML file. See source for full documentation of expected blocks.
-`prn=false` silences the transform, wing-frame and aero-setup messages loading a
-structure prints.
+`wind_mode=PerPointWind()` builds a structure whose points carry their own settable
+wind. `prn=false` silences the transform, wing-frame and aero-setup messages loading
+a structure prints.
 """
-function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_yaml", set::Union{Nothing,Settings}=nothing, ignore_l0::Bool=false, dynamics_type::Union{Nothing,WingType}=nothing, aero_mode::Union{Nothing,AbstractAeroModel}=nothing, vsm_set::Union{Nothing,VortexStepMethod.VSMSettings}=nothing, wing_type::Union{Nothing,WingType}=nothing, prn::Bool=true)
+function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_yaml", set::Union{Nothing,Settings}=nothing, ignore_l0::Bool=false, dynamics_type::Union{Nothing,WingType}=nothing, aero_mode::Union{Nothing,AbstractAeroModel}=nothing, vsm_set::Union{Nothing,VortexStepMethod.VSMSettings}=nothing, wing_type::Union{Nothing,WingType}=nothing, wind_mode::WindMode=ProfileWind(), prn::Bool=true)
     if !isnothing(wing_type)
         if !isnothing(dynamics_type)
             error("Cannot specify both `wing_type` and `dynamics_type`; `wing_type` is deprecated, use `dynamics_type`.")
@@ -1087,5 +1088,5 @@ function load_sys_struct_from_yaml(yaml_path::AbstractString; system_name="from_
     return SystemStructure(system_name, resolved_set; points, twist_surfaces,
         segments, pulleys, tethers, winches, wings,
         transforms, bodies, elastic_joints, timoshenko_joints,
-        ignore_l0, vsm_set, prn)
+        ignore_l0, vsm_set, wind_mode, prn)
 end

--- a/test/test_per_point_wind.jl
+++ b/test/test_per_point_wind.jl
@@ -47,8 +47,9 @@ system:
 
 solver:
     solver: "FBDF"
-    abs_tol: 0.0001
-    rel_tol: 0.0001
+    # below the 1e-6 parity checked here: the two wind paths take different solver steps
+    abs_tol: 1e-9
+    rel_tol: 1e-9
     relaxation: 0.6
 
 kite:

--- a/test/test_per_point_wind.jl
+++ b/test/test_per_point_wind.jl
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: 2026 Bart van de Lint
+# SPDX-License-Identifier: LGPL-3.0-only
+
+# test_per_point_wind.jl - Wind set per point (PerPointWind)
+#
+# Verifies:
+# 1. A uniform per-point wind reproduces the height profile of a constant law
+# 2. A segment's tether drag flies in the mean of its two endpoints' winds
+# 3. A wind written between steps reaches that step's own point
+
+using Pkg
+if abspath(PROGRAM_FILE) == abspath(@__FILE__)
+    Pkg.activate(@__DIR__)
+end
+
+@isdefined(test_init!) || include(joinpath(@__DIR__, "util.jl"))
+
+using Test
+using SymbolicAWEModels
+using SymbolicAWEModels: KVec3
+using KiteUtils
+using LinearAlgebra
+
+# Two free points on a stiff vertical segment: both carry point drag (area,
+# drag_coeff) and the segment carries tether drag, so every wind consumer is live.
+PER_POINT_WIND_YAML = """
+##############################
+## Per-Point Wind Test #######
+##############################
+
+points:
+  headers: [name, pos_cad, type, wing_idx, transform_idx, extra_mass, body_frame_damping, world_frame_damping, area, drag_coeff]
+  data:
+    - [point_top, [0.0, 0.0, 60.0], DYNAMIC, nothing, nothing, 0.5, 0.0, 0.0, 0.02, 1.0]
+    - [point_bottom, [0.0, 0.0, 50.0], DYNAMIC, nothing, nothing, 0.5, 0.0, 0.0, 0.02, 1.0]
+
+segments:
+  headers: [name, point_i, point_j, l0, diameter_mm, unit_stiffness, unit_damping, compression_frac]
+  data:
+    - [vert_segment, point_top, point_bottom, 10.0, 4.0, 100000.0, 100.0, 0.1]
+"""
+
+PER_POINT_WIND_SETTINGS = """
+system:
+    log_file: "data/per_point_wind_test"
+    g_earth:     0.0
+
+solver:
+    solver: "FBDF"
+    abs_tol: 0.0001
+    rel_tol: 0.0001
+    relaxation: 0.6
+
+kite:
+    model: ""
+    foil_file: "ram_air_kite/ram_air_kite_foil.dat"
+    physical_model: "2plate"
+    struc_geometry_path: "particle_structural_geometry.yaml"
+    aero_geometry_path: "aero_geometry.yaml"
+    mass: 0.0
+
+tether:
+    cd_tether: 0.958
+    unit_damping: 0.0
+    unit_stiffness: 0.0
+    rho_tether: 724.0
+    e_tether: 5.5e10
+
+winch:
+    winch_model: "TorqueControlledMachine"
+    drum_radius: 0.110
+    gear_ratio: 1.0
+    inertia_total: 0.024
+    f_coulomb: 122.0
+    c_vf: 30.6
+
+environment:
+    rho_0: 1.225
+    v_wind: 10.0
+    upwind_dir: -90.0
+    upwind_elevation: 0.0
+    wind_vec: [10.0, 0.0, 0.0]
+    use_wind_vec: true
+    profile_law: 0
+"""
+
+"""
+Step a fresh model on `wind_mode` and return both points' position and velocity.
+`winds` gives the per-point wind written before every step, and `point_drag=false`
+zeroes the points' own drag area so only the segment's tether drag acts.
+"""
+function stepped_state(set, yaml_path, wind_mode; steps = 40, dt = 0.05,
+                       winds = nothing, point_drag = true)
+    sys = load_sys_struct_from_yaml(yaml_path;
+        system_name = "per_point_wind_test", set, wind_mode)
+    sam = SymbolicAWEModel(set, sys)
+    test_init!(sam; prn=false)
+    point_drag || foreach(point -> (point.area = 0.0), sam.sys_struct.points)
+    for _ in 1:steps
+        isnothing(winds) || for (point, wind) in zip(sam.sys_struct.points, winds)
+            point.wind_vec .= wind
+        end
+        next_step!(sam; dt, vsm_interval=0)
+    end
+    return [copy(point.pos_w) for point in sam.sys_struct.points],
+           [copy(point.vel_w) for point in sam.sys_struct.points]
+end
+
+@testset "Per-point wind tests" begin
+    tmpdir = mktempdir()
+    yaml_path = joinpath(tmpdir, "per_point_wind_geometry.yaml")
+    write(yaml_path, PER_POINT_WIND_YAML)
+    write(joinpath(tmpdir, "settings.yaml"), PER_POINT_WIND_SETTINGS)
+    write(joinpath(tmpdir, "system.yaml"), "system:\n  sim_settings: settings.yaml\n")
+
+    data_path_before = get_data_path()
+    set_data_path(tmpdir)
+    set = Settings("system.yaml")
+    uniform = [KVec3(set.wind_vec), KVec3(set.wind_vec)]
+
+    # ========================================================================
+    # A uniform per-point wind is the constant profile law
+    # ========================================================================
+    @testset "Uniform per-point wind matches the constant profile" begin
+        profile_pos, profile_vel = stepped_state(set, yaml_path, ProfileWind())
+        per_point_pos, per_point_vel =
+            stepped_state(set, yaml_path, PerPointWind(); winds = uniform)
+
+        for k in eachindex(profile_pos)
+            @test per_point_pos[k] ≈ profile_pos[k] rtol=1e-6
+            @test per_point_vel[k] ≈ profile_vel[k] rtol=1e-6
+        end
+        # The wind actually drove the points downwind, so the parity is not a
+        # comparison of two systems that both did nothing.
+        @test profile_vel[1][1] > 1.0
+    end
+
+    # ========================================================================
+    # A segment's drag flies in the mean of its endpoints' winds
+    # ========================================================================
+    @testset "Tether drag takes the mean of the two endpoints" begin
+        split = [KVec3(20.0, 0.0, 0.0), KVec3(0.0, 0.0, 0.0)]
+        mean_pos, mean_vel = stepped_state(set, yaml_path, PerPointWind();
+            winds = uniform, point_drag = false)
+        split_pos, split_vel = stepped_state(set, yaml_path, PerPointWind();
+            winds = split, point_drag = false)
+
+        for k in eachindex(mean_pos)
+            @test split_pos[k] ≈ mean_pos[k] rtol=1e-6
+            @test split_vel[k] ≈ mean_vel[k] rtol=1e-6
+        end
+        @test mean_vel[1][1] > 0.1
+        # Only the segment pushes, and it pushes both endpoints alike.
+        @test split_vel[1][1] ≈ split_vel[2][1] rtol=1e-6
+    end
+
+    # ========================================================================
+    # A wind written per point acts at that point
+    # ========================================================================
+    @testset "Per-point wind drives its own point" begin
+        windward = [KVec3(20.0, 0.0, 0.0), KVec3(0.0, 0.0, 0.0)]
+        _, vel = stepped_state(set, yaml_path, PerPointWind();
+                               steps = 20, winds = windward)
+        @test vel[1][1] > vel[2][1]          # the windward point leads
+        @test vel[2][1] > 0.0                # dragged along by the segment
+        @test vel[1][1] < windward[1][1]     # but not faster than its own wind
+
+        _, reversed = stepped_state(set, yaml_path, PerPointWind();
+                                    steps = 20, winds = reverse(windward))
+        @test reversed[2][1] > reversed[1][1]
+    end
+
+    set_data_path(data_path_before)
+end

--- a/test/test_pulley.jl
+++ b/test/test_pulley.jl
@@ -559,7 +559,8 @@ system:
             loads = SymbolicAWEModels.segment_load_terms(
                 nothing, src, still, dst, KVec3(0.0, 0.0, separation_speed),
                 unit_stiffness, unit_damping, 0.1, 1.0, l0, 0.005, 724.0,
-                0.0, still, nothing; with_drag=false, rest_len_rate)
+                0.0, SymbolicAWEModels.PrescribedWindSource(still);
+                with_drag=false, rest_len_rate)
             return loads.spring, loads.spring_vel
         end
 


### PR DESCRIPTION
A `SystemStructure` now carries a `wind_mode`. The default `ProfileWind()` is the
height profile `set.profile_law` as before; `PerPointWind()` turns every
`point.wind_vec` into a parameter the caller writes between steps.

```julia
sys_struct = load_sys_struct_from_yaml(path; set, wind_mode=PerPointWind())
sam = SymbolicAWEModel(set, sys_struct)
init!(sam)
for _ in 1:steps
    for point in sam.sys_struct.points
        point.wind_vec .= my_wind_field(point.pos_w, sam.integrator.t)
    end
    sam.sys_struct.wings[1].wind_vec .= my_wind_field(...)
    next_step!(sam)
end
```

### Why a type and not a `profile_law` number

`AtmosphericModels` owns the `profile_law` integers (0..6), so any number picked
there could collide with a law it adds later. The mode is a type on the structure
instead, which is also how every other build-time switch here is modelled
(backends, aero modes, winch models). A third wind source is a new singleton plus
methods rather than a breaking change.

### One abstraction, both backends

`AbstractWindSource` is resolved once per consumer at build time, so the equations
carry no runtime branch:

| consumer | `PerPointWind` source |
| --- | --- |
| point drag / apparent wind | `point.wind_vec` |
| tether drag | mean of the segment's two endpoints |
| wing (rigid VSM operating point) | `wing.wind_vec` |
| VSM panels | unchanged — they already gather inflow per structural point |

The segment mean is computed in the equations, not in Julia; there is no per-step
refresh pass and no derived struct field. The monolith reads the endpoint winds
from the `wind_at_point` variables it already has. A segment kernel cannot: it is
instanced over `:segments` and the registry remaps one index per container, so it
reaches neither endpoint through a path. It mints `src_wind`/`dst_wind`, which
`bind_segment_winds!` points at the endpoints' `point.wind_vec` per instance — the
way a pulley leg gets its side. Under `ProfileWind` the segment still evaluates the
profile at its midpoint and mints nothing.

`reinit!` seeds every point and wing with `set.wind_vec`, so a model that is never
written to flies in a uniform wind. Only `PerPointWind` enters the sys-struct hash,
so structures on the default keep their cached builds.

### Breaking

`wing.v_wind` is renamed `wing.wind_vec`: it is a vector like `point.wind_vec`, and
the old name read as the scalar `set.v_wind`.

### Testing

Not run locally; the package precompiles and loads clean. `test/test_per_point_wind.jl`
is auto-discovered and runs on both backends. It asserts that a uniform per-point
wind reproduces the constant profile exactly, that a split 20/0 wind gives the same
motion as a uniform 10 (so the segment really takes the mean), and that a wind
written between steps drives its own point and reverses when the winds swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)