### PR TITLE
cleanup: apply_heading and the two frames the placement fix stopped us

### DIFF
--- a/docs/src/private_functions.md
+++ b/docs/src/private_functions.md
@@ -63,7 +63,6 @@ SymbolicAWEModels.smooth_norm
 SymbolicAWEModels.smooth_sign
 SymbolicAWEModels.coulomb_viscous_friction
 SymbolicAWEModels.smooth_normalize
-SymbolicAWEModels.apply_heading
 SymbolicAWEModels.get_rot_pos
 SymbolicAWEModels.get_base_pos
 SymbolicAWEModels.calc_aoa

--- a/src/system_structure/transforms.jl
+++ b/src/system_structure/transforms.jl
@@ -5,7 +5,7 @@
 Transform functions for heading calculation and spatial positioning.
 
 This file contains:
-- Heading calculation functions (calc_heading, apply_heading, etc.)
+- Heading calculation functions (calc_heading, apply_heading!, etc.)
 - reinit! and reposition! functions for applying transforms
 
 Note: The Transform struct and its constructors are defined in types.jl
@@ -14,16 +14,6 @@ Note: The Transform struct and its constructors are defined in types.jl
 function finalize_transforms! end
 
 # ==================== HEADING CALCULATION ==================== #
-
-"""
-    apply_heading(vec, R_t_to_w, curr_R_t_to_w, heading)
-
-Apply a heading rotation to a vector.
-"""
-function apply_heading(vec, R_t_to_w, curr_R_t_to_w, heading)
-    vec_along_z = rotate_around_z(curr_R_t_to_w' * vec, heading)
-    return R_t_to_w * vec_along_z
-end
 
 """
     wrap_to_pi(angle)
@@ -200,7 +190,7 @@ it (points and bodies). Rotates the current radial onto the target radial by the
 minimal (roll-free) rotation, so placement never depends on the source frame —
 which is undefined when the components start at the zenith. Roll about the radial
 is set afterwards by the heading step, which is well-defined at the target
-elevation/azimuth. Returns `(curr_R_t_to_w, R_t_to_w)` for use in that step.
+elevation/azimuth.
 """
 function apply_azimuth_elevation!(transform, points, bodies, base_pos)
     curr_rot_pos = get_rot_pos(transform, bodies, points)
@@ -212,11 +202,9 @@ function apply_azimuth_elevation!(transform, points, bodies, base_pos)
               "elevation/azimuth rotation. Use transform_idx: 0 to skip " *
               "transforms, or adjust positions.")
     end
-    curr_R_t_to_w = calc_R_t_to_w(rel_pos)
 
     transform_pos = rotate_around_z(
         rotate_around_y([1, 0, 0], -transform.elevation), -transform.azimuth)
-    R_t_to_w = calc_R_t_to_w(transform_pos)
 
     if abs(abs(transform.elevation) - π / 2) < 1e-6
         @warn "Transform #$(transform.idx): elevation = " *
@@ -239,8 +227,6 @@ function apply_azimuth_elevation!(transform, points, bodies, base_pos)
         end
         body.Q_b_to_w .= rotation_matrix_to_quaternion(R_b)
     end
-
-    return curr_R_t_to_w, R_t_to_w
 end
 
 """
@@ -265,8 +251,7 @@ function apply_spherical_velocity!(transform, points, bodies, base_pos)
 end
 
 """
-    apply_heading!(transform, points, bodies,
-                    curr_R_t_to_w, R_t_to_w, base_pos)
+    apply_heading!(transform, points, bodies, base_pos)
 
 Apply heading rotation to all components in a single transform.
 Rotates around the radial axis through `base_pos` (not the origin).
@@ -276,8 +261,7 @@ After `copy_cad_to_world!`, this equals `R_b_to_c` (for
 Bodies in the transform rotate with the same heading delta; a transform
 without a body target applies no heading (matching point behavior).
 """
-function apply_heading!(transform, points, bodies,
-                         curr_R_t_to_w, R_t_to_w, base_pos)
+function apply_heading!(transform, points, bodies, base_pos)
     reference_body = heading_reference_body(transform, bodies)
     isnothing(reference_body) && return
 
@@ -463,10 +447,8 @@ function reinit!(transforms::AbstractVector{Transform}, sys_struct::SystemStruct
         end
 
         # ==================== ROTATE + HEADING ==================== #
-        curr_R_t_to_w, R_t_to_w = apply_azimuth_elevation!(
-            transform, points, bodies, base_pos)
-        apply_heading!(transform, points, bodies,
-            curr_R_t_to_w, R_t_to_w, base_pos)
+        apply_azimuth_elevation!(transform, points, bodies, base_pos)
+        apply_heading!(transform, points, bodies, base_pos)
         update_vel && apply_spherical_velocity!(
             transform, points, bodies, base_pos)
     end
@@ -504,11 +486,8 @@ function reposition!(
             points[something(
                 transform.base_point_idx)].pos_w
         end
-        curr_R_t_to_w, R_t_to_w =
-            apply_azimuth_elevation!(
-                transform, points, bodies, base_pos)
-        apply_heading!(transform, points, bodies,
-            curr_R_t_to_w, R_t_to_w, base_pos)
+        apply_azimuth_elevation!(transform, points, bodies, base_pos)
+        apply_heading!(transform, points, bodies, base_pos)
         update_vel && apply_spherical_velocity!(
             transform, points, bodies, base_pos)
     end


### PR DESCRIPTION
### TL;DR

`510a4232` replaced tether-frame placement with `min_rotation` and made `apply_heading!` read the body's own orientation, and neither change took its scaffolding out. This drops the now-dead `apply_heading` helper and the two rotation matrices `apply_azimuth_elevation!` still built, returned and handed to a callee that never looked at them.

### What was left behind

`apply_heading(vec, R_t_to_w, curr_R_t_to_w, heading)` had no callers. `grep -rn apply_heading` over the repo found exactly three hits: the definition, the file's header list, and the `@docs` entry on `docs/src/private_functions.md`.

`apply_azimuth_elevation!` computed `curr_R_t_to_w = calc_R_t_to_w(rel_pos)` and `R_t_to_w = calc_R_t_to_w(transform_pos)` and returned the pair; `reinit!` and `reposition!` each destructured it and threaded both into `apply_heading!`. The body of `apply_heading!` reads neither — since `510a4232` it takes its orientation from `heading_reference_body` and rotates about `normalize(reference_body.pos_w - base_pos)`. So the two `calc_R_t_to_w` calls existed only to fill a return value nobody consumed, and the docstring line "Returns `(curr_R_t_to_w, R_t_to_w)` for use in that step" described a contract that had stopped being one.

### What is gone

The helper and its docs entry; the two `calc_R_t_to_w` calls; the return tuple and that docstring line; the two parameters on `apply_heading!` and the destructuring at both call sites. Nothing else changes: `calc_R_t_to_w` stays live through `calc_heading` (and `test_heading_calculation.jl` exercises it directly), `transform_pos` is still what `min_rotation` rotates onto, and `rotate_around_z` is still used a few lines below. The file header's function list now names `apply_heading!`, the one that exists.

No `CHANGELOG.md` entry: nothing observable changes. `apply_heading` is private and had no callers, and the deleted return values had no readers.

### The red job is not this diff, and I did not touch it

`Julia 1.12 - ubuntu-latest - x64 - monolith` errored in `test/test_twist_alignment.jl:123` with `AssertionError: VSM solve failed (non-converged or non-finite) on wing 1` — 3143 passed, 0 failed, 1 errored. The other five jobs of that run, `Julia 1.11 - ubuntu`, `Julia 1.12 - macOS`, the kernel-backend cell on the very same ubuntu 1.12 image, Documentation and reuse-lint, are green, and so was the full suite on the box.

The deletion is inert on that test, measured rather than argued: I ran `test/test_twist_alignment.jl` here, then put the parent commit's `src/system_structure/transforms.jl` back with `git checkout c3b2b562^ -- …` and ran it again in the same session. Static twists `[-0.1336630477312238, -0.0008835202645692225, -0.1319843929300836]` and dynamic `[0.9221199567195998, -0.0033309221603231233, 0.7965616094657846]`, identical to the last bit on both. It has to be: the two deleted `calc_R_t_to_w` calls are pure (`smooth_normalize` and a cross product, `src/generate_system/helpers.jl:210`) and nothing read their results.

What the test does is ramp steering for 60 steps and assert on the state it lands in, which its own comment says is next to a divergence: "Holding this steering runs the station twist away until the VSM solve diverges, so a settled operating point does not exist for this 2-plate config." Same code, four platforms, end states from 0.22 to 1.05 and once past the assertion in `vsm_aero_coeffs`. It last went red the same way on `feat/point-flap-delta` (#288, `93ac34cd`, ubuntu 1.12 monolith and no other cell), whose own later head and merge into `main` both passed. I opened #316 with the six-run table and what I would do about it. It is a behaviour test with a real fix behind it, so it does not ride inside a deletion PR, and weakening it to get this one green is the thing I must not do.

### Where I would push back

The other obvious follow-up — a test pinning what `apply_azimuth_elevation!` and `apply_heading!` do near the vertical, where the old frame-based placement was undefined — is #312. Also a behaviour test, also not this diff.

### Verification

- [x] Reproduced first: n/a — dead-code removal. The claim it rests on is `grep -rn apply_heading`, which found the definition, the header line and the docs entry and no call.
- [x] `test/test_transform.jl`: `Transform Tests | 325 325` — all pass, twice (4m31s cold, 17.5s on the warm cache after the last edit). juliaserver, `examples` env.
- [x] `test/test_heading_calculation.jl`: `Heading - Circular Path | 72 72`, `Heading - Horizontal Circle | 48 48`, `Heading - Special Cases | 22 22`. This is the file that keeps `calc_R_t_to_w` honest now that only `calc_heading` reaches it.
- [x] `test/test_twist_alignment.jl` (the file CI errored in): green here, and bit-identical with the parent commit's `transforms.jl` swapped back in — numbers above.
- [x] Local CI mirror (`agent ci-local`): PASS (70 min, Julia 1.12.7, one cell of the matrix) — weak evidence next to GitHub CI, but it is the cell that went red there.
- [x] GitHub CI: six of the seven jobs pass — Documentation, reuse-lint, `Julia 1.11 - ubuntu`, `Julia 1.12 - windows`, `Julia 1.12 - macOS` and the kernel-backend cell on the same ubuntu 1.12 image. `Julia 1.12 - ubuntu monolith` is the one red, on `test_twist_alignment.jl` → #316, not this diff. I re-ran that cell alone and its six siblings went green a second time; the cell itself was still running when I wrote this, 1h28m into a 180-minute budget, so this PR's own check badge is the live answer and I am not transcribing a guess for it. Either verdict leaves the reading unchanged — green makes it the flake #316 describes, red makes it the second sighting on this commit, and neither can come from a diff that is bit-identical on this test.
- [ ] Docs build: not run here — `docs/` carries no manifest and building it would resolve one, which `AGENTS.md` §2 keeps out of my hands. The `@docs` entry and the docstring it pointed at go in the same commit, so there is no orphan either way; the Documentation job is green.
- [ ] REUSE lint: not run here — `reuse` is not installed on this box. Neither touched file changes a licence header, and the `reuse-lint` job is green.
- [x] Up to date with `main`: the branch was at `origin/main` when pushed, no rebase needed.
- Benchmark: n/a — two `calc_R_t_to_w` calls per transform at init only, not on any stepped path.
- Risk: none I can see; the removed values had no readers. If something outside this repo calls `SymbolicAWEModels.apply_heading` through the private API it breaks — it is not exported and not in the public docs.

### Scope

+8 / -30 across 2 files: `src/system_structure/transforms.jl` and one line off `docs/src/private_functions.md`. No stack — no open PR touches `transforms.jl`. Found while answering #254; filed #316 on the way.


Closes #313 · task `SymbolicAWEModels.jl-313`
