### PR TITLE
Nothing tests that a transform lands on its heading near the vertical


### DIFF
--- a/test/test_heading_calculation.jl
+++ b/test/test_heading_calculation.jl
@@ -30,8 +30,7 @@ using LinearAlgebra
 using KiteUtils
 using SymbolicAWEModels
 using SymbolicAWEModels: smooth_normalize, sym_calc_R_t_to_w,
-    calc_heading, calc_R_t_to_w, Point, Body, Transform,
-    SystemStructure, reinit!, quaternion_to_rotation_matrix
+    calc_heading, calc_R_t_to_w, reinit!, quaternion_to_rotation_matrix
 
 # `Settings` reads through the process-wide data path; leave it as found.
 prev_data_path = get_data_path()

--- a/test/test_heading_calculation.jl
+++ b/test/test_heading_calculation.jl
@@ -8,6 +8,10 @@ Verifies that `calc_heading` correctly projects the body x-axis
 onto the tangent plane of the tether sphere and returns the
 angle from the elevation direction (x_t) toward azimuthal (y_t).
 
+Also places a body through `reinit!` from a near-vertical CAD
+pose and verifies it lands on the transform's heading, where the
+tether frame the pose sits in is degenerate.
+
 Tests run with both origin and non-origin base positions to
 verify heading is computed relative to the sphere center.
 
@@ -23,8 +27,17 @@ end
 
 using Test
 using LinearAlgebra
+using KiteUtils
+using SymbolicAWEModels
 using SymbolicAWEModels: smooth_normalize, sym_calc_R_t_to_w,
-    calc_heading, calc_R_t_to_w
+    calc_heading, calc_R_t_to_w, Point, Body, Transform,
+    SystemStructure, reinit!, quaternion_to_rotation_matrix
+
+# `Settings` reads through the process-wide data path; leave it as found.
+prev_data_path = get_data_path()
+set_data_path(joinpath(dirname(@__DIR__), "data", "2plate_kite"))
+set = Settings("system.yaml")
+set_data_path(prev_data_path)
 
 # Support selective test execution via command-line args
 const test_patterns = isempty(ARGS) ? String[] : ARGS
@@ -124,6 +137,39 @@ function test_special_cases(base_pos, label)
     end
 end
 
+function heading_after_reinit(base_pos, dx, target_heading)
+    cad_pos = base_pos + [dx, 0.0, 51.0]
+    kite = Body(:kite; mass=1.0, inertia_principal=ones(3),
+                pos=cad_pos, transform=:main_tf)
+    points = [Point(:ground, base_pos, STATIC; transform=0),
+              Point(:kite_origin, cad_pos, BODY_STATIC;
+                    body=:kite, anchor_b=zeros(3),
+                    transform=:main_tf)]
+    transforms = [Transform(:main_tf, deg2rad(70), deg2rad(20),
+                      target_heading; base_pos=base_pos,
+                      base_point=:ground, rot_point=:kite_origin)]
+
+    sys = SystemStructure("near_vertical_heading", set;
+        points, bodies=[kite], transforms, prn=false)
+    reinit!(sys, set; prn=false)
+
+    placed = sys.bodies[:kite]
+    return calc_heading(
+        quaternion_to_rotation_matrix(placed.Q_b_to_w),
+        placed.pos_w - sys.points[:ground].pos_w)
+end
+
+function test_near_vertical_placement(base_pos, label)
+    @testset "Near-Vertical Placement ($label)" begin
+        target_heading = deg2rad(30)
+        for dx in [0.0, 1e-3, -1e-3, 1e-2, -1e-2]
+            @test heading_after_reinit(
+                base_pos, dx, target_heading) ≈
+                target_heading atol=1e-10
+        end
+    end
+end
+
 base_positions = [
     (zeros(3), "origin base"),
     ([10.0, -5.0, 3.0], "non-origin base"),
@@ -149,6 +195,14 @@ if should_run_test("special")
 @testset "Heading - Special Cases" begin
     for (bp, label) in base_positions
         test_special_cases(bp, label)
+    end
+end
+end
+
+if should_run_test("vertical")
+@testset "Heading - Near-Vertical Placement" begin
+    for (bp, label) in base_positions
+        test_near_vertical_placement(bp, label)
     end
 end
 end


### PR DESCRIPTION
### TL;DR

Adds a testset to `test/test_heading_calculation.jl` that places a body 51 m up in CAD, a hair off the transform's rotation axis, runs `reinit!` and asserts the body lands on `transform.heading`. #254's 180° flip no longer reproduces, but nothing guarded the fix, and the frame degeneracy it rode on is still live.

### What was unguarded

`OpenSourceAWE/SymbolicAWEModels.jl@510a4232` ended #254 in two places: `apply_azimuth_elevation!` now rotates the current radial onto the target one with `min_rotation` instead of composing two tether frames, and `apply_heading!` measures the body's own `Q_b_to_w` instead of re-applying the azimuth/elevation rotation that had already been applied. Neither has a test that would notice it going back.

The rest of the heading coverage cannot notice: `test/test_heading_calculation.jl` is pure geometry — it builds no `SystemStructure` and never calls `reinit!` — and `test/test_transform.jl` round-trips `transform.heading` only at elevation 80° with the wing well off the axis.

The degeneracy those two changes route around is unchanged and still reachable. At 51 m standoff `calc_R_t_to_w` (`src/generate_system/helpers.jl:210`) gives tangent frames exactly 180° apart for a millimetre of horizontal offset either way:

```
calc_R_t_to_w([+1e-3, 0, 51])[:, 2] = [-0.0,  1.0, 0.0]
calc_R_t_to_w([-1e-3, 0, 51])[:, 2] = [-0.0, -1.0, 0.0]   → 180.0°
```

So the new testset is what stands between that frame and the placement path.

### The test

One `Body` at `base_pos + [dx, 0, 51]` in CAD, a co-located `BODY_STATIC` point as the transform's `rot_point`, a `Transform` at 70° elevation / 20° azimuth / 30° heading, `reinit!`, then `calc_heading` on the placed body's world orientation — asserted equal to `transform.heading` for `dx` of `0`, `±1 mm` and `±1 cm`, from both an origin and a non-origin base. It builds no `SymbolicAWEModel`, so it compiles nothing and adds no model-cache entry; the whole testset runs in 0.1 s.

The construction is `test/test_rigid_body.jl:148`'s idiom, the one place in the suite that already puts a plain `Body` through a `Transform` at the `SystemStructure` level. `Settings` has to come through the process-wide data path, so the file reads `data/2plate_kite` and puts the path back as it found it rather than writing a second copy of a settings YAML — the suite has two of those already.

### Against #314

#314 rewrites the `apply_heading!` this test pins, so I ran the new testset with `src/system_structure/transforms.jl` taken from that branch: `10/10` pass, file total `152/152`. The two do not touch the same file and are not stacked; whichever lands first, this testset is the thing that would have caught #314 changing behaviour, and it says it does not.

### Where I would push back

The assertion is self-consistent by construction: `apply_heading!` measures the heading with the same `calc_R_t_to_w` the test measures it back with, at the *target* position where the frame is well-defined. That is what makes it a placement test and not a frame test — it pins the contract (`reinit!` puts the body on `transform.heading`) and is blind to the frame convention itself. A test for the degeneracy proper belongs beside `calc_R_t_to_w`, and #313 is already in that file.

### Verification

- [x] Reproduced first: n/a — the bug does not reproduce on `main`; the frame degeneracy it rode does, quoted above.
- [x] Red before green: with `apply_heading!`'s no-ref-points branch reverted to its pre-`510a4232` form, `0 passed, 10 failed` — `0.852` rad for `dx ≥ 0` against a target of `0.524`, and `-2.289` rad for `dx < 0`, i.e. the 18.8° double-application error *and* the 180.0° flip. Restored, `10/10` pass.
- [x] `test/test_heading_calculation.jl`: `152/152` pass, 0.5 s (juliaserver, exit 0). Re-run in a fresh module namespace after the import trim: `152/152`.
- [x] With #314's `transforms.jl`: `152/152`, near-vertical `10/10`.
- [x] Data path is left as found: verified from a `mktempdir` ambient path, `before == after`.
- [x] Up to date with `origin/main` (0 behind). Lines ≤ 92 chars.
- [ ] Local full suite: not run — the diff touches no `src/`. `agent ci-local` is running; last turn's attempt was reaped by the box's OOM killer before it produced output. GitHub CI triggers on this pull request.
- [ ] Docs: not built — no `src/` or `docs/` change and no new public symbol, so `make.jl` has nothing new to resolve. Changelog: no entry — test-only, nothing user-visible. REUSE lint: not run, `reuse` is not installed on the box; the file's SPDX header is untouched.
- Risk: the file now sets the process-wide data path to read `Settings` and restores it. A later test file that depended on the ambient path would break if that restore ever stopped happening.

### Scope

+54 / -1 in one file, `test/test_heading_calculation.jl`, all of it the new testset and the `Settings` bootstrap it needs. No `src/` change. Not stacked: #314 is open on `src/system_structure/transforms.jl`, a file this diff does not touch, and this branch was already pushed before it existed.


Closes #312 · task `SymbolicAWEModels.jl-312`
