### PR TITLE
Give the two stale examples the point types that replaced WING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## Unreleased
+
+### Fixed
+- `sam_tutorial.jl` and `kps4_comparison.jl` build their wing points again. Both
+  still passed the `WING` `DynamicsType` that v0.13.0 removed, so the tutorial
+  died with `UndefVarError: WING` on the step that adds the kite. A rigid wing's
+  structural nodes are now `BODY_STATIC` riding its body and a particle wing's
+  are `DYNAMIC`; the tutorial's wing is rigid, so it also declares the three
+  stations that the removal of `auto_create_twist_surfaces!` requires.
+
 ## v0.17.0 12-09-2026
 
 ### Added

--- a/examples/kps4_comparison.jl
+++ b/examples/kps4_comparison.jl
@@ -116,13 +116,13 @@ push!(points, Point(:kcu, pos_kcu, DYNAMIC;
     transform=:main_tf))
 push!(points, Point(:nose, pos_nose, DYNAMIC;
     extra_mass=k_nose, transform=:main_tf))
-push!(points, Point(:top, pos_top, WING;
+push!(points, Point(:top, pos_top, DYNAMIC;
     extra_mass=k_top, wing=:plate_wing,
     transform=:kite_tilt))
-push!(points, Point(:right, pos_right, WING;
+push!(points, Point(:right, pos_right, DYNAMIC;
     extra_mass=k_side, wing=:plate_wing,
     transform=:kite_tilt))
-push!(points, Point(:left, pos_left, WING;
+push!(points, Point(:left, pos_left, DYNAMIC;
     extra_mass=k_side, wing=:plate_wing,
     transform=:kite_tilt))
 

--- a/examples/sam_tutorial.jl
+++ b/examples/sam_tutorial.jl
@@ -109,21 +109,23 @@ vsm_set = VortexStepMethod.VSMSettings(
 vsm_wing = VortexStepMethod.Wing(vsm_set)
 vsm_aero = BodyAerodynamics([vsm_wing])
 vsm_solver = Solver(vsm_aero, vsm_set)
-wings = [SymbolicAWEModels.Wing(1, vsm_aero, vsm_wing,
-    vsm_solver, [], I(3), [0.5, 0, set.l_tether + 6])]
-
-# WING-type points: 3 LE/TE pairs matching the 3 aero sections
+# One station per aero section joins its LE/TE pair to the wing.
 wing_z = set.l_tether + 6
-for (_, y) in enumerate([-1.0, 0.0, 1.0])
+stations = Station[]
+for (i, y) in enumerate([-1.0, 0.0, 1.0])
     n = length(points)
     push!(points, Point(n + 1, [-0.5, y, wing_z],
-        WING; wing=1, transform=1, extra_mass=0.1))
+        BODY_STATIC; wing=1, transform=1, extra_mass=0.1))
     push!(points, Point(n + 2, [0.5, y, wing_z],
-        WING; wing=1, transform=1, extra_mass=0.1))
+        BODY_STATIC; wing=1, transform=1, extra_mass=0.1))
+    push!(stations, Station(i, [n + 1, n + 2], DYNAMIC, 0.25))
 end
 
+wings = [SymbolicAWEModels.Wing(1, vsm_aero, vsm_wing,
+    vsm_solver, eachindex(stations), I(3), [0.5, 0, wing_z])]
+
 sys = SystemStructure("wing", set;
-    points, segments, tethers, winches, pulleys,
+    points, stations, segments, tethers, winches, pulleys,
     wings, transforms)
 sam = SymbolicAWEModel(set, sys)
 @info "Wing model created successfully"


### PR DESCRIPTION
### TL;DR

`sam_tutorial.jl` and `kps4_comparison.jl` still passed the `WING` `DynamicsType` that v0.13.0 removed, so the tutorial died with `UndefVarError: WING` on the step that adds the kite and has been taking `Setup Test` down on `main` since 2026-09-07. Each example now carries the point type its own wing implies — `DYNAMIC` for the particle wing, `BODY_STATIC` for the rigid one — and the tutorial declares the stations a section-coupled rigid wing has needed since `auto_create_twist_surfaces!` went away.

### Which type is not a judgement call

#324 left the choice open, on the grounds that `BODY_STATIC` versus `DYNAMIC` is a call about what a tutorial is for. It is not: the removal commit `8516368b` says "points now carry real types — DYNAMIC (particle wing) or BODY_STATIC riding the wing body (rigid wing)", and the `Point` and `DynamicsType` docstrings say the same. The type follows the wing the example already builds, so each file has exactly one right answer and they are different answers.

`kps4_comparison.jl` builds `PlateWing(...; dynamics_type=PARTICLE_DYNAMICS)` and its three points are already the sole members of its three stations, so they are `DYNAMIC` and the rest of the file is untouched — three words.

`sam_tutorial.jl` calls `SymbolicAWEModels.Wing(1, vsm_aero, vsm_wing, vsm_solver, ...)`, which dispatches to the pre-created-objects `VSMWing`. That constructor never forwards `dynamics_type`, so the wing is always `RIGID_DYNAMICS` with `AeroLinearized`, and its six points are `BODY_STATIC` riding it (`wing=1`: a wing is a body). That wing is also section-coupled and declared no stations, which is its own error now that `auto_create_twist_surfaces!` is gone — "Section-coupled aero on RIGID wing 1 requires explicit stations covering its LE/TE structural sections; none were declared". So step 4 builds one `Station` per LE/TE pair in the loop that already builds the pair, and hands them to the wing. `validate_station_modes` wants `DYNAMIC` twist to sit on a rigid wing and to have at least two points a station, which is what an LE/TE pair is, and `moment_frac` 0.25 matches `data/2plate_kite/rigid_structural_geometry.yaml`, the repo's own rigid wing.

The loop's `wing_z` moved three lines up so the wing and the points read one definition of it rather than two spellings of `set.l_tether + 6`.

### What the two examples build now

There is no before to put beside these: both files die on the line that pushes their first wing point, so before this branch neither reaches anything that can be drawn. The before is the `UndefVarError` under Verification. All three come off the branch head through the repo's own headless recipe, `plot(sam.sys_struct)` and `plot_body_frame` under `GLMakie.activate!(; visible=false)`, as `docs/generate_figures.jl` renders the figures in the docs.

![sam_tutorial.jl step 4: the whole system, tether to wing, as plot(sam.sys_struct) renders it](https://github.com/user-attachments/assets/4a0c949f-11fb-4b74-aec9-c4c7e0fe4396)

The tutorial's step 4 entire: the 20-segment tether on transform 1's −85° elevation, the pulley pair at the end of it, and the wing's six points past those.

![sam_tutorial.jl step 4: the wing's six points, three LE/TE pairs, one station each](https://github.com/user-attachments/assets/ecff030e-25f8-4661-b414-e715f74c021e)

The same six in the wing's own frame, from above: three LE/TE pairs at y = −1, 0, 1 and x = ∓0.5, a `Station` each, all six `BODY_STATIC` on wing 1. These are the points that carried `WING`.

![kps4_comparison.jl: the plate kite's three wing points in its body frame](https://github.com/user-attachments/assets/9e936e8b-0b20-45bc-ba48-158de0446e4e)

`kps4_comparison.jl`'s three in the same view — `:top` above, `:right` and `:left` at the tips, a station each, `DYNAMIC` under its particle wing.

### What I found and did not fix

`examples/kps4_comparison.jl` cannot run in any environment this repository ships. Its line 18 is `using KiteModels`, and `KiteModels` appears in none of this repo's five `Project.toml` files. That is why it is absent from the `Setup Test` run list, and why its copy of this bug went unannounced. I could only exercise the half I changed; see Verification. Adding the dependency is a decision about whether that comparison is meant to be runnable, which is not mine to take inside this diff.

That half does run, and it does not park. Over the example's own 30 s at 50 ms a step the kite leaves 70.8° elevation and reaches −39.7°, passing from +142 m to −96 m on a tether pinned at 150 m while the winch force climbs from 0 to 1571 N — a pendulum, not a parked kite. Nothing in this branch can cause or cure that: the three words it changes are the only reason the model builds at all, and `WING` on a particle wing meant `DYNAMIC` before it was removed. Whether the trajectory is right is the question the example exists to answer, and it cannot be answered here without `KiteModels`. Worth its own thread once the file can be run whole.

![kps4_comparison.jl: elevation and azimuth over the 30 s run](https://github.com/user-attachments/assets/7ff79e32-5a9b-4ac3-a6d7-6a2d76b01e8a)

`.github/workflows/setup-test.yml` triggers on `push` to `main` and `workflow_dispatch` only. Nothing runs the examples on a pull request, so an example can break and only announce it after it is merged — which is exactly what happened here, and it is why no check on this pull request runs an example at all; the local run of that job's own script, below, is what stands in for it. I would add `pull_request` to the trigger, but at 120 minutes a run that is a real cost on every pull request, so it deserves its own thread rather than a line in this one.

`test/test_helpers.jl:50` asserts that each tracked `Manifest-v1.1x.toml.default` is no older than `Project.toml`, and the proxy is mtime, so the gate's own `git merge origin/main` trips it whenever the merge rewrites `Project.toml` — which is what turned an earlier local mirror of this branch red, with all three files byte-identical to `main`. #305 is open on exactly that and proposes the content check that replaces the proxy; the mechanism is a comment there, the test is untouched here, and this round's merge left `Project.toml` alone so it passes again.

### Verification

- [x] Reproduced first: `LoadError: UndefVarError: WING not defined`, `examples/sam_tutorial.jl:119` — the signature #324 quotes from CI
- [x] `examples/sam_tutorial.jl` red before, green after, re-run whole on the branch head (juliaserver): steps 1–3 simulate, then "RIGID_DYNAMICS wing 1: COM=[[0.0, 0.0, 56.0]], I=[0.4, 0.15, 0.55]" and "Wing model created successfully"
- [x] `examples/kps4_comparison.jl`: its own lines 26–35 and 84–256 verbatim, without the `KiteModels` half, red before with the same `UndefVarError` and green after — model `kps4_particle_plate_dynamic_11pnt_15seg_3grp_1wng_1wch_1bdy` built and initialised, `SymAWE section twists [deg]=[4.0, 10.0, 10.0]`, the whole 30 s run at 700× realtime, 601 logged states
- [x] `test/setup_integration.jl` — the job that is red — run whole on this branch: `Test Summary: End-user setup | Pass 19 | Total 19 | 64m07.4s`, no errors. All nine examples in its run list and both README blocks pass; before, `run sam_tutorial.jl` was the one error and 19 of 20 passed. That run predates the two merges since, whose only change on this side of the branch is changelog headings, so both examples were re-run whole instead of the 64 minutes again, with the outputs above
- [x] Local full suite (`agent ci-local`, Julia 1.12.7, fail-fast, one cell of the matrix): `Testing SymbolicAWEModels... | 3525 | 3525 | 29m08.3s`, exit 0 — `test_helpers.jl` included, which the earlier mirror of this branch tripped over for the reason above
- [x] GitHub CI green on the branch head `955b83a0`: all seven checks — the five test cells (1.12 ubuntu monolith and kernel, 1.12 macOS, 1.12 windows, 1.13 ubuntu), `Documentation`, and `reuse-lint`, which is the licence gate the box cannot run for want of `reuse`. `Setup Test` does not run on pull requests, so `test/setup_integration.jl` above is what stands for it
- [x] Up to date with `main` (`558b27c7`). Three syncs, each conflicting only in `CHANGELOG.md` where both sides had opened a section under `## Unreleased`; kept both every time
- Docs: n/a, no new or renamed public symbol
- Risk: the tutorial's step 4 constructs the model and never solves it, so this proves the structure is buildable, not that a rigid VSM wing hanging off a pulley is physically sensible. The kps4 half does solve, and what it solves to is the second finding above

### Scope

+19 / -11 across 3 files; `examples/kps4_comparison.jl` is three occurrences of `WING` → `DYNAMIC` and nothing else. Closes #324.

Closes #324 · task `SymbolicAWEModels.jl-324`
