### PR TITLE
One switch for both workloads: `precompile_workload` now reaches the Makie extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## Unreleased
+
+### Fixed
+- `precompile_workload = false` now switches off the Makie extension's workload as
+  well as the package's, so precompiling `SymbolicAWEModelsMakieExt` no longer
+  builds four models and loading it no longer replaces the package's own
+  precompiled copies of the model pipeline.
+
 ## v0.17.0 12-09-2026
 
 ### Added

--- a/ext/SymbolicAWEModelsMakieExt.jl
+++ b/ext/SymbolicAWEModelsMakieExt.jl
@@ -4357,12 +4357,15 @@ function SymbolicAWEModels.plot_aoa(sys_struct::SystemStructure;
     return fig
 end
 
-using PrecompileTools: @setup_workload, @compile_workload
+using PrecompileTools: @setup_workload, @compile_workload, workload_enabled
 
-@setup_workload begin
-    fixture = SymbolicAWEModels.workload_fixture()
-    @compile_workload begin
-        SymbolicAWEModels.run_workload(fixture)
+# @setup_workload would read this extension module's preference, not the package's.
+if workload_enabled(SymbolicAWEModels)
+    @setup_workload begin
+        fixture = SymbolicAWEModels.workload_fixture()
+        @compile_workload begin
+            SymbolicAWEModels.run_workload(fixture)
+        end
     end
 end
 

--- a/src/precompile_workload.jl
+++ b/src/precompile_workload.jl
@@ -6,9 +6,7 @@ using PrecompileTools: @setup_workload, @compile_workload
 """
     workload_fixture() -> String
 
-Copy the 2-plate fixture into a scratch directory and return its path. The
-workload builds real models and `init!` serialises one, so it must not write into
-the package's own `data`.
+Copy the 2-plate fixture into a scratch directory and return its path.
 """
 function workload_fixture()
     source = joinpath(@__DIR__, "..", "data", "2plate_kite")
@@ -26,7 +24,7 @@ end
     workload_model(fixture, geometry, system_name, backend) -> SymbolicAWEModel
 
 Load the 2-plate structure from `geometry` and build it on `backend`, ready for
-`init!`. Reloads the structure per call because building consumes it.
+`init!`. Reloads the structure on every call.
 """
 function workload_model(fixture, geometry, system_name, backend)
     set = Settings("system.yaml")
@@ -43,9 +41,7 @@ end
     run_workload(fixture)
 
 Build, initialise and step the 2-plate models on both backends. Called from this
-package's workload and again from the Makie extension's, where the same code is
-compiled against the method table Makie leaves behind — loading Makie invalidates
-around 19500 method instances, and a cold start is almost entirely inference.
+package's `@compile_workload` and from the Makie extension's.
 """
 function run_workload(fixture)
     set_data_path(fixture)


### PR DESCRIPTION
### TL;DR

`[SymbolicAWEModels] precompile_workload = false` switched off the package's `@compile_workload` and left the identical block at the end of `SymbolicAWEModelsMakieExt` running, because PrecompileTools resolves that preference for the module the workload sits in and an extension is a module of its own. This makes one switch govern both, which takes 340 s off every extension precompile in this repository.

**It is not the fix for #287, and this pull request should not close it.** That became clear only after the work was done; the section below says why, and the issue needs to stay open.

### The preference does not reach the extension

`PrecompileTools.workload_enabled(mod)` reads `load_preference(mod, "precompile_workload", true)`, and `Preferences.get_uuid` resolves that per module. Probed in the `examples` project, and again in `test`:

```
SymbolicAWEModels          uuid 9c9a347c-…   preference false   workload_enabled false
SymbolicAWEModelsMakieExt  uuid ba1985c5-…   preference unset   workload_enabled true
```

Every project in this repository sets it false — `LocalPreferences.toml.default`, `examples/`, `test/`, `docs/` — and it was propagated to `examples` and `test` in `OpenSourceAWE/SymbolicAWEModels.jl@37cdb7da`, an hour and a half after `OpenSourceAWE/SymbolicAWEModels.jl@9450f90b` added the workload, so it is deliberate and current. So inside this repository the extension's workload was the only one still running anywhere, building four models on every precompile of the extension, and then loading its own copies of the model-building path over the package's.

The extension now asks PrecompileTools about the package instead of letting it ask about itself. Ten lines, and the preference means what it says.

### Why this is not #287

#287 is about a downstream consumer, and downstream the preference is **not** false. `OpenSourceAWE/V3Kite.jl`'s `examples/LocalPreferences.toml.default` reads:

```toml
[V3Kite]
precompile_workload = false
```

That switches off V3Kite's own workload and says nothing about SymbolicAWEModels, so there `workload_enabled(SymbolicAWEModels)` is `true`. V3Kite's `examples/Project.toml` carries both `GLMakie` and `MakieControlPlots`, which is exactly what triggers `SymbolicAWEModelsMakieExt` (weakdeps `GeometryBasics` + `MakieControlPlots`). Both workloads therefore run, this gate passes, and **nothing in this diff changes anything for that user.**

The numbers below were all taken against an image built with the package's workload *off*, which is the only case this change touches. In particular the "0 of ours invalidated by `using CairoMakie`" figure was measured against a nearly empty package image and says nothing about a populated one. The measurement #287 actually needs — invalidations counted against a package image built *with* its workload, as V3Kite gets — is written and staged but **not run**: the box was at load 64–69 on 20 cores with 20 of 31 GB of swap in use and it killed the session mid-precompile. Running it on a box in that state would have cost other agents their runs for a number I could not trust anyway.

So: merge this for what it is, and leave #287 open.

### Measured, and only for the preference-false case

| | before | after |
| --- | --- | --- |
| precompiling the extension | 359977 ms | 21163 ms |
| `SymbolicAWEModels` instances discarded when it loads | 720 | 0 |
| `run_workload` cold, extension loaded | 97.33 s | — |
| `run_workload` cold, no Makie (what you get instead) | 366.94 s / 323.58 s | unchanged |

340 s off every extension precompile and no displaced code, against the first model build going back to ~330 s from 97 s. If the first build matters more, the answer is not to let the extension ignore the switch — it is to set `precompile_workload = true` in `LocalPreferences.toml.default`, which is now the one place that decides it for both.

Counts are unique `CodeInstance.def` out of `invalidations.logedges`, grouped by owning module. On Julia 1.12 `SnoopCompile.uinvalidated` reports 88 where the log holds 27896 `CodeInstance` entries, and `invalidation_trees` attributes insertions to packages loaded before the window opened; neither survives a sanity check, which is why nothing here uses them.

### Found on the way

- `plot(syss, logs; plot_gk=true)` cannot run: `ext/SymbolicAWEModelsMakieExt.jl:1836` reads `cs_over_us_vec`, which is defined nowhere. Live code, no coverage. Its own decision about what the diagnostic should report, so it is #329 rather than a hunk here.
- The extension file has accreted badly around that area and I left it alone: the `MakieControlPlots.plot` method at :1326 runs to :2414, 1089 lines on 32 keyword arguments; 75 of the 90 lines at :1847-1936 are commented-out code; 87 lines in the file are over 92 characters; `setup_replay_controls!`'s `get_dt` is documented at :3539 and read nowhere in its body; and `gk_ylims` is accepted by that `plot` method and never read, which is the same `plot_gk` path as #329. A `cleanup:` PR of its own, not something to hide inside this diff.
- `test/test_makie_extension.jl` run from the repository's own project skips itself: the root `Project.toml` has no `GLMakie`, so the file's availability probe fails and the suite reports one broken test and passes. It has to be run with the `test` project activated, which is what `runtests.jl` does and what the runs below did. Harmless in CI, quietly misleading anywhere else.
- Where the numbers were taken: `./bin/install -y` exited 128 on this worktree, another process holding the extension's precompile pidfile. The tree is complete and loads, and every measurement here ran on it, so I did not re-run the script.

### Verification

- [x] Reproduced first: `workload_enabled` false for the package and true for the extension, in the `examples` project and again in `test` over the merge (table above)
- [x] `using MakieControlPlots` discards 720 `SymbolicAWEModels` instances before, 0 after — fresh processes, same counter, same box, minutes apart, package workload off
- [x] Extension precompile 359977 ms → 21163 ms; package precompile with the workload off 17086 ms
- [x] `test/test_makie_extension.jl`: 15/15 pass, 6m09.9s, against the merged tree (15/15 in 4m19s before the merge, and 15/15 in 3m56s against unchanged code)
- [x] Docs build clean (exit 0; only the pre-existing `size_threshold_warn` warnings of #301) · merged up to date with `origin/main`
- [x] Local full suite over the merged head: PASS, 34 min, Julia 1.12, one cell of the matrix
- [x] GitHub CI on the merged head `6486330e`: all seven checks pass — the four Julia 1.12 cells (ubuntu monolith and kernel, windows, macOS aarch64), Julia 1.13 ubuntu, Documentation and reuse-lint. Its matrix still carries `fail-fast: false`, which is #307 and not this branch.
- [x] REUSE lint clean, in that `reuse-lint` job; no files added or removed. `./bin/reuse_lint` cannot run on this box, `reuse` is not installed there.
- [ ] **Not run:** invalidations against a package image built *with* its workload — the case #287 is about. Script staged at `.agent/scratch/enabled_workload.jl`; the box killed the session mid-precompile at load 64–69 with 20 of 31 GB swap used.
- [ ] No unit test: the gate only does anything while a package is being precompiled, so what it changes is not observable from a running session. The before/after pair above is the evidence.
- Benchmark: `run_workload` 366.94 s / 323.58 s baseline against 97.33 s with the extension's workload loaded, 0.28× — allocations are not the quantity here, this is compile time. Box: steady — max 13 of 20 cores busy, 1.8-4.0 GHz, 24500M free at its lowest, 3 other agents; `agent bench-end`: "conditions held". An earlier window was discarded on its verdict.
- Risk: `PrecompileTools.workload_enabled` is not exported. It is the same predicate PrecompileTools applies to the package, which is why the gate uses it rather than a second preference lookup and a new `Preferences` dependency, and it exists in every version `[compat]` allows (1.2.1, 1.3.3, 1.3.4) — but a 2.0 that renamed it would silently take the workload with it.

### Scope

+18 / -13 across 3 files, in three commits: the gate and its changelog entry, the three workload docstrings (which said why rather than what and carried a method-instance count matching neither #261's own record of 18058 nor this measurement), and the merge of `origin/main`. No open pull request touches `ext/` or the workload. **Refs #287; does not close it** — the `Closes #287` line appended to this body is wrong and needs removing before merge.

Refs #287 · task `SymbolicAWEModels.jl-287`
